### PR TITLE
feat: 모바일 헤더 메뉴 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,22 +1,21 @@
 <!DOCTYPE html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/src/assets/main_logo.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>UPbrella | 공유 우산 플랫폼</title>
-    <script
-      type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<%= kakaoKey %>&libraries=services"
-    ></script>
-    <!-- Naver Map  -->
-    <script
-      type="text/javascript"
-      src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=<%= naverKey %>"
-    ></script>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/src/assets/main_logo.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UPbrella | 공유 우산 플랫폼</title>
+  <script type="text/javascript"
+    src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<%= kakaoKey %>&libraries=services"></script>
+  <!-- Naver Map  -->
+  <script type="text/javascript"
+    src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=<%= naverKey %>"></script>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/src/components/atoms/LocationClassificationBtn/index.tsx
+++ b/src/components/atoms/LocationClassificationBtn/index.tsx
@@ -1,17 +1,15 @@
+import { TClassification } from "@/types/admin/StoreTypes";
 import { useState } from "react";
 
 export type TLocationClassificationBtn = {
-  classifications: {
-    name: string;
-    latitude?: number | null;
-    longitude?: number | null;
-  }[];
+  classifications: TClassification[];
   map?: naver.maps.Map;
 };
 
 const LocationClassificationBtn = ({ classifications, map }: TLocationClassificationBtn) => {
   const [activeIndex, setActiveIndex] = useState(0);
 
+  // console.log(classifications, "ghkrdldkdkd");
   const handleClick = (index: number) => {
     setActiveIndex(index);
 

--- a/src/components/atoms/LocationClassificationBtn/index.tsx
+++ b/src/components/atoms/LocationClassificationBtn/index.tsx
@@ -3,15 +3,21 @@ import { useState } from "react";
 
 export type TLocationClassificationBtn = {
   classifications: TClassification[];
+  setSelectedClassification: React.Dispatch<React.SetStateAction<number | 0>>;
   map?: naver.maps.Map;
 };
 
-const LocationClassificationBtn = ({ classifications, map }: TLocationClassificationBtn) => {
+const LocationClassificationBtn = ({
+  classifications,
+  setSelectedClassification,
+  map,
+}: TLocationClassificationBtn) => {
   const [activeIndex, setActiveIndex] = useState(0);
 
-  // console.log(classifications, "ghkrdldkdkd");
-  const handleClick = (index: number) => {
+  const handleClick = (index: number, classificationId: number) => {
     setActiveIndex(index);
+
+    setSelectedClassification(classificationId);
 
     if (map && window.naver && window.naver.maps) {
       const location = classifications[index];
@@ -33,7 +39,7 @@ const LocationClassificationBtn = ({ classifications, map }: TLocationClassifica
               ? "text-primary-500 border-primary-500"
               : "text-gray-700 border-gray-300"
           } font-semibold px-16 py-8 mr-8 rounded-999 border text-15 bg-white`}
-          onClick={() => handleClick(index)}
+          onClick={() => handleClick(index, item.id)}
         >
           {item.name}
         </button>

--- a/src/components/atoms/LocationClassificationBtn/index.tsx
+++ b/src/components/atoms/LocationClassificationBtn/index.tsx
@@ -1,33 +1,35 @@
 import { useState } from "react";
 
 export type TLocationClassificationBtn = {
-  text: string[];
+  classifications: {
+    name: string;
+    latitude?: number | null;
+    longitude?: number | null;
+  }[];
   map?: naver.maps.Map;
 };
 
-const LocationClassificationBtn = ({ text, map }: TLocationClassificationBtn) => {
+const LocationClassificationBtn = ({ classifications, map }: TLocationClassificationBtn) => {
   const [activeIndex, setActiveIndex] = useState(0);
 
   const handleClick = (index: number) => {
     setActiveIndex(index);
 
     if (map && window.naver && window.naver.maps) {
-      const shinchon = new window.naver.maps.LatLng(37.5608393877042, 126.93545258588699);
-      const yeonhee = new window.naver.maps.LatLng(37.573885406749994, 126.93472815974937);
-
-      if (index === 0) {
-        map.setCenter(shinchon);
-      } else {
-        map.setCenter(yeonhee);
-      }
+      const location = classifications[index];
+      const newCenter = new window.naver.maps.LatLng(
+        location.latitude ?? 0,
+        location.longitude ?? 0
+      );
+      map.setCenter(newCenter);
     }
   };
 
   return (
     <div>
-      {text.map((item, index) => (
+      {classifications.map((item, index) => (
         <button
-          key={item}
+          key={item.name}
           className={`${
             activeIndex === index
               ? "text-primary-500 border-primary-500"
@@ -35,7 +37,7 @@ const LocationClassificationBtn = ({ text, map }: TLocationClassificationBtn) =>
           } font-semibold px-16 py-8 mr-8 rounded-999 border text-15 bg-white`}
           onClick={() => handleClick(index)}
         >
-          {item}
+          {item.name}
         </button>
       ))}
     </div>

--- a/src/components/molecules/Header/HeaderContents.tsx
+++ b/src/components/molecules/Header/HeaderContents.tsx
@@ -5,9 +5,10 @@ import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined
 import HeaderMyPage from "@/components/atoms/Header/HeaderMyPage";
 import MenuIcon from "@mui/icons-material/Menu";
 import { NavLink } from "react-router-dom";
+import MobileMenu from "../MobileMenu";
 
 export type HeaderContentsProps = {
-  isLogin?: boolean;
+  isLogin: boolean;
   name?: string;
 };
 
@@ -32,17 +33,22 @@ const headerNavItems = [
 
 const HeaderContents = ({ isLogin, name }: HeaderContentsProps) => {
   const navigate = useNavigate();
-  const [isOpen, setIsOpen] = useState(false);
+  const [infoBubbleOpen, setInfoBubbleOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const handleMyPageOpen = () => {
-    setIsOpen(!isOpen);
+    setInfoBubbleOpen(!infoBubbleOpen);
+  };
+
+  const handleMenuOpen = () => {
+    setMenuOpen(true);
   };
 
   return (
     <>
-      <div className="flex justify-between items-center mt-8 relative lg:hidden">
+      <div className="flex justify-between items-center my-8 px-40 relative lg:hidden">
         <Link to={"/"}>
-          <img className="w-64 h-64" src={Logo} alt="Logo" />
+          <img className="w-64 h-64 p-8" src={Logo} alt="Logo" />
         </Link>
         <div className="flex justify-between text-16 font-semibold leading-24 text-gray-700">
           {headerNavItems.map(({ name, path }) => (
@@ -67,7 +73,7 @@ const HeaderContents = ({ isLogin, name }: HeaderContentsProps) => {
             <div className="flex items-center cursor-pointer relative" onClick={handleMyPageOpen}>
               <PersonOutlineOutlinedIcon sx={{ fontSize: "20px" }} />
               <div className="ml-4">{name}님</div>
-              {isOpen && (
+              {infoBubbleOpen && (
                 <div className="absolute top-11 right-0">
                   <HeaderMyPage />
                 </div>
@@ -83,14 +89,22 @@ const HeaderContents = ({ isLogin, name }: HeaderContentsProps) => {
           )}
         </div>
       </div>
-      <div className="flex justify-center items-center mt-8 relative xl:hidden">
-        <div className="absolute left-0 mt-18">
+
+      <div
+        className={menuOpen ? "hidden" : "flex justify-center items-center mt-8 relative xl:hidden"}
+      >
+        <div className="absolute left-0 mt-18" onClick={handleMenuOpen}>
           <MenuIcon style={{ width: "28px", height: "28px" }} />
         </div>
         <Link to={"/"} className="mt-8">
           <img className="w-48 h-48" src={Logo} alt="Logo" />
         </Link>
       </div>
+      {menuOpen && (
+        <div className="mx-40 xl:hidden">
+          <MobileMenu isLogin={isLogin} setMenuOpen={setMenuOpen} />
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/molecules/Header/HeaderContents.tsx
+++ b/src/components/molecules/Header/HeaderContents.tsx
@@ -101,8 +101,8 @@ const HeaderContents = ({ isLogin, name }: HeaderContentsProps) => {
         </Link>
       </div>
       {menuOpen && (
-        <div className="flex justify-center items-center">
-          <div className="xl:hidden lg:w-full max-w-640">
+        <div className="fixed top-0 left-0 right-0 bottom-0 flex justify-center bg-white p-20">
+          <div className="xl:hidden lg:w-full lg:max-w-640 sm:w-full sm:max-w-360">
             <MobileMenu isLogin={isLogin} setMenuOpen={setMenuOpen} />
           </div>
         </div>

--- a/src/components/molecules/Header/HeaderContents.tsx
+++ b/src/components/molecules/Header/HeaderContents.tsx
@@ -46,7 +46,7 @@ const HeaderContents = ({ isLogin, name }: HeaderContentsProps) => {
 
   return (
     <>
-      <div className="flex justify-between items-center my-8 px-40 relative lg:hidden">
+      <div className="flex justify-between items-center w-full px-40 my-8 relative lg:hidden">
         <Link to={"/"}>
           <img className="w-64 h-64 p-8" src={Logo} alt="Logo" />
         </Link>
@@ -101,8 +101,10 @@ const HeaderContents = ({ isLogin, name }: HeaderContentsProps) => {
         </Link>
       </div>
       {menuOpen && (
-        <div className="mx-40 xl:hidden">
-          <MobileMenu isLogin={isLogin} setMenuOpen={setMenuOpen} />
+        <div className="flex justify-center items-center">
+          <div className="xl:hidden lg:w-full max-w-640">
+            <MobileMenu isLogin={isLogin} setMenuOpen={setMenuOpen} />
+          </div>
         </div>
       )}
     </>

--- a/src/components/molecules/MobileMenu/index.stories.tsx
+++ b/src/components/molecules/MobileMenu/index.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryFn } from "@storybook/react";
+import MobileMenu, { TMenu } from ".";
+import { BrowserRouter } from "react-router-dom";
+
+export default {
+  title: "Molecules/MobileMenu",
+  component: MobileMenu,
+  args: {
+    isLogin: true,
+    setMenuOpen: () => {
+      // console.log("Menu is open:");
+    },
+  },
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<TMenu> = ({ isLogin, setMenuOpen }) => (
+  <MobileMenu isLogin={isLogin} setMenuOpen={setMenuOpen} />
+);
+
+export const Default = Template.bind({});

--- a/src/components/molecules/MobileMenu/index.tsx
+++ b/src/components/molecules/MobileMenu/index.tsx
@@ -44,18 +44,6 @@ const MobileMenu: React.FC<TMenu> = ({ isLogin, setMenuOpen }) => {
 
         <div className="flex flex-col py-20">
           {isLogin ? (
-            <div className="mb-4">
-              <div className="font-semibold text-20 text-gray-700 mb-16">
-                업브렐라를 찾아주셔서 감사해요!
-              </div>
-              <button
-                className="rounded-8 font-semibold w-full py-12 text-white bg-primary-500"
-                onClick={() => handleNavToUrl("/login")}
-              >
-                로그인
-              </button>
-            </div>
-          ) : (
             <div className="flex justify-between mb-4">
               <div className="flex items-center mr-12 font-semibold text-20">
                 <PersonOutlineIcon />
@@ -66,6 +54,18 @@ const MobileMenu: React.FC<TMenu> = ({ isLogin, setMenuOpen }) => {
                 onClick={() => handleNavToUrl("/mypage")}
               >
                 마이페이지 <NavigateNextIcon fontSize="small" />
+              </button>
+            </div>
+          ) : (
+            <div className="mb-4">
+              <div className="font-semibold text-20 text-gray-700 mb-16">
+                업브렐라를 찾아주셔서 감사해요!
+              </div>
+              <button
+                className="rounded-8 font-semibold w-full py-12 text-white bg-primary-500"
+                onClick={() => handleNavToUrl("/login")}
+              >
+                로그인
               </button>
             </div>
           )}
@@ -84,7 +84,7 @@ const MobileMenu: React.FC<TMenu> = ({ isLogin, setMenuOpen }) => {
             </>
           ))}
           <div className="bg-gray-200 w-full h-1 my-16"></div>
-          {!isLogin && (
+          {isLogin && (
             <button className="flex mx-16 text-14 text-gray-500 font-semibold">로그아웃</button>
           )}
         </div>

--- a/src/components/molecules/MobileMenu/index.tsx
+++ b/src/components/molecules/MobileMenu/index.tsx
@@ -34,7 +34,7 @@ const MobileMenu: React.FC<TMenu> = ({ isLogin, setMenuOpen }) => {
     <div className="relative w-full">
       <div className="bg-white z-100">
         <div className="flex justify-between items-center py-16">
-          <Link to={"/"} className="mt-8">
+          <Link to={"/"}>
             <img className="w-32 h-32" src={Logo} alt="Logo" />
           </Link>
           <div onClick={handleMenuClose}>

--- a/src/components/molecules/MobileMenu/index.tsx
+++ b/src/components/molecules/MobileMenu/index.tsx
@@ -1,0 +1,96 @@
+import { TMobileMenu } from "@/types/commonTypes";
+import { Link, useNavigate } from "react-router-dom";
+import { NavLink } from "react-router-dom";
+import Logo from "@/assets/main_logo.svg";
+import CloseSharpIcon from "@mui/icons-material/CloseSharp";
+import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
+import NavigateNextIcon from "@mui/icons-material/NavigateNext";
+
+export type TMenu = {
+  isLogin: boolean;
+  setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const MobileMenu: React.FC<TMenu> = ({ isLogin, setMenuOpen }) => {
+  const navigate = useNavigate();
+
+  const headerNavItems: TMobileMenu[] = [
+    { name: "업브렐라 이야기", path: "/" },
+    { name: "대여소 위치", path: "/" },
+    { name: "협업 지점 소개", path: "/" },
+    { name: "이용안내", path: "/" },
+  ];
+
+  const handleMenuClose = () => {
+    setMenuOpen(false);
+  };
+
+  const handleNavToUrl = (url: string) => {
+    setMenuOpen(false);
+    navigate(url);
+  };
+
+  return (
+    <div className="relative">
+      <div className="bg-white z-100">
+        <div className="flex justify-between items-center py-16">
+          <Link to={"/"} className="mt-8">
+            <img className="w-32 h-32" src={Logo} alt="Logo" />
+          </Link>
+          <div onClick={handleMenuClose}>
+            <CloseSharpIcon />
+          </div>
+        </div>
+
+        <div className="flex flex-col py-20">
+          {isLogin ? (
+            <div className="mb-4">
+              <div className="font-semibold text-20 text-gray-700 mb-16">
+                업브렐라를 찾아주셔서 감사해요!
+              </div>
+              <button
+                className="rounded-8 font-semibold w-full py-12 text-white bg-primary-500"
+                onClick={() => handleNavToUrl("/login")}
+              >
+                로그인
+              </button>
+            </div>
+          ) : (
+            <div className="flex justify-between mb-4">
+              <div className="flex items-center mr-12 font-semibold text-20">
+                <PersonOutlineIcon />
+                <span className="ml-8">홍길동님</span>
+              </div>
+              <button
+                className="flex items-center justify-center text-primary-500 bg-primary-200 rounded-99 pl-16 pr-6 py-8 text-14 font-semibold"
+                onClick={() => handleNavToUrl("/mypage")}
+              >
+                마이페이지 <NavigateNextIcon fontSize="small" />
+              </button>
+            </div>
+          )}
+          {headerNavItems.map(({ name, path }) => (
+            <>
+              <div className="bg-gray-200 w-full h-1 my-16"></div>
+              <div>
+                <NavLink
+                  key={name}
+                  to={path}
+                  className="px-16 text-15 text-gray-700 hover:text-primary-500 font-semibold"
+                >
+                  {name}
+                </NavLink>
+              </div>
+            </>
+          ))}
+          <div className="bg-gray-200 w-full h-1 my-16"></div>
+          {!isLogin && (
+            <button className="flex mx-16 text-14 text-gray-500 font-semibold">로그아웃</button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MobileMenu;

--- a/src/components/molecules/MobileMenu/index.tsx
+++ b/src/components/molecules/MobileMenu/index.tsx
@@ -31,7 +31,7 @@ const MobileMenu: React.FC<TMenu> = ({ isLogin, setMenuOpen }) => {
   };
 
   return (
-    <div className="relative">
+    <div className="relative w-full">
       <div className="bg-white z-100">
         <div className="flex justify-between items-center py-16">
           <Link to={"/"} className="mt-8">

--- a/src/components/organisms/Header/HeaderContainer.tsx
+++ b/src/components/organisms/Header/HeaderContainer.tsx
@@ -7,7 +7,7 @@ export const HeaderContainer = () => {
       {/* 로그인한 경우 */}
       {/* <HeaderContents isLogin name="김민희" />  */}
       {/* 로그인하지 않은 경우 */}
-      <HeaderContents />
+      <HeaderContents isLogin={false} />
     </div>
   );
 };

--- a/src/components/pages/RentalLocation/RentalLocationPage.tsx
+++ b/src/components/pages/RentalLocation/RentalLocationPage.tsx
@@ -50,14 +50,7 @@ export default function RentalInfo() {
   // server
   const { data: classificationsRes } = useGetClassifications();
 
-  const classificationData =
-    classificationsRes?.map((item) => ({
-      name: item.name,
-      latitude: item.latitude,
-      longitude: item.longitude,
-    })) || [];
-
-  // console.log("map is ", map);
+  // console.log("classification is ", classificationsRes);
 
   return (
     <div className="flex flex-col mt-24">
@@ -69,10 +62,12 @@ export default function RentalInfo() {
         </div>
         <div className="w-full max-w-936 rounded-20 relative">
           <Map ref={mapElement} width="100%" height="896px" borderRadius="20px" />
-          <div className="absolute top-0 left-0 z-10 p-24">
-            <LocationClassificationBtn classifications={classificationData} map={map} />
+          <div className="absolute top-0 left-0 z-9 p-24">
+            {classificationsRes && (
+              <LocationClassificationBtn classifications={classificationsRes} map={map} />
+            )}
           </div>
-          <div className="absolute top-0 right-7 z-10 pt-86">
+          <div className="absolute top-0 right-7 z-10 pt-86 lg:hidden">
             <MapBtn map={map} />
           </div>
         </div>

--- a/src/components/pages/RentalLocation/RentalLocationPage.tsx
+++ b/src/components/pages/RentalLocation/RentalLocationPage.tsx
@@ -6,8 +6,9 @@ import LocationClassificationBtn from "@/components/atoms/LocationClassification
 import MapBtn from "@/components/molecules/MapBtn";
 import "@/styles/markerLabel.css";
 import Card from "@/components/organisms/Card";
+import { useGetClassifications } from "@/hooks/queries/storeQueries";
 
-// 신촌 좌표
+// 기본 위치 좌표
 export const DEFAULT_COORDINATE = {
   lat: 37.5608393877042,
   lng: 126.93545258588699,
@@ -46,17 +47,30 @@ export default function RentalInfo() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [naver]);
 
+  // server
+  const { data: classificationsRes } = useGetClassifications();
+
+  const classificationData =
+    classificationsRes?.map((item) => ({
+      name: item.name,
+      latitude: item.latitude,
+      longitude: item.longitude,
+    })) || [];
+
+  // console.log("map is ", map);
+
   return (
     <div className="flex flex-col">
       <div className="flex justify-center">
         {/* 태블렛 환경에서 대여지점 카드 hidden */}
+
         <div className="sm:hidden pr-24">
           <Card />
         </div>
         <div className="w-full max-w-936 rounded-20 relative">
           <Map ref={mapElement} width="100%" height="896px" borderRadius="20px" />
           <div className="absolute top-0 left-0 z-10 p-24">
-            <LocationClassificationBtn text={["신촌", "연희동"]} map={map} />
+            <LocationClassificationBtn classifications={classificationData} map={map} />
           </div>
           <div className="absolute top-0 right-7 z-10 pt-86">
             <MapBtn map={map} />

--- a/src/components/pages/RentalLocation/RentalLocationPage.tsx
+++ b/src/components/pages/RentalLocation/RentalLocationPage.tsx
@@ -17,6 +17,7 @@ export const DEFAULT_COORDINATE = {
 export default function RentalInfo() {
   const { naver } = window;
   const mapElement = useRef(null);
+  const [, setSelectedClassification] = useState(221);
 
   const [map, setMap] = useState<naver.maps.Map>();
   const [, setMarker] = useState<naver.maps.Marker>();
@@ -49,9 +50,6 @@ export default function RentalInfo() {
 
   // server
   const { data: classificationsRes } = useGetClassifications();
-
-  // console.log("classification is ", classificationsRes);
-
   return (
     <div className="flex flex-col mt-24">
       <div className="flex justify-center">
@@ -64,7 +62,11 @@ export default function RentalInfo() {
           <Map ref={mapElement} width="100%" height="896px" borderRadius="20px" />
           <div className="absolute top-0 left-0 z-9 p-24">
             {classificationsRes && (
-              <LocationClassificationBtn classifications={classificationsRes} map={map} />
+              <LocationClassificationBtn
+                classifications={classificationsRes}
+                setSelectedClassification={setSelectedClassification}
+                map={map}
+              />
             )}
           </div>
           <div className="absolute top-0 right-7 z-10 pt-86 lg:hidden">

--- a/src/components/pages/RentalLocation/RentalLocationPage.tsx
+++ b/src/components/pages/RentalLocation/RentalLocationPage.tsx
@@ -60,7 +60,7 @@ export default function RentalInfo() {
   // console.log("map is ", map);
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col mt-24">
       <div className="flex justify-center">
         {/* 태블렛 환경에서 대여지점 카드 hidden */}
 

--- a/src/components/pages/home/HomeMainPage.tsx
+++ b/src/components/pages/home/HomeMainPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
 const navItems = [
@@ -27,21 +27,21 @@ const navItems = [
 const HomeMainPage = () => {
   const navigate = useNavigate();
 
+  // mui component의 default z-index에 의한 모바일 메뉴 요소 겹침문제로 인해 mui 대신 기본 버튼을 썼습니다
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-10">
       <Typography variant="h5">헤더 메뉴에 없는 개발중인 페이지입니다.</Typography>
 
       {navItems.map(({ name, path }) => (
-        <Button
+        <button
           key={name}
-          variant="contained"
-          className="!bg-primary-500"
+          className="bg-primary-500 text-white rounded-10 px-10 py-10 shadow-md"
           onClick={() => {
             navigate(path);
           }}
         >
           {name}
-        </Button>
+        </button>
       ))}
     </div>
   );

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -29,11 +29,13 @@ const RentalOfficePage = () => {
       </div>
       <div>
         <LocationClassificationBtn classifications={classificationName} />
-        <div className="font-bold	text-24 mt-64 ml-5 mb-16">신촌</div>
-        <div className="grid  grid-cols-3 grid-flow-row gap-4 lg:grid-cols-2">
-          {storeData.map((store, index) => (
-            <Store key={index} title={store.title} category={store.category} />
-          ))}
+        <div>
+          <div className="font-bold	text-24 mt-64 ml-5 mb-16">신촌</div>
+          <div className="grid  grid-cols-3 grid-flow-row gap-4 lg:grid-cols-2">
+            {storeData.map((store, index) => (
+              <Store key={index} title={store.title} category={store.category} />
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -1,7 +1,8 @@
 import LocationClassificationBtn from "@/components/atoms/LocationClassificationBtn";
 import Card from "@/components/organisms/Card";
 import Store from "@/components/molecules/Store";
-import { useGetSubClassifications } from "@/hooks/queries/storeQueries";
+import { useGetClassifications } from "@/hooks/queries/storeQueries";
+import { useState } from "react";
 
 const RentalOfficePage = () => {
   const storeData = [
@@ -13,14 +14,11 @@ const RentalOfficePage = () => {
     { title: "또 다른 가게 이름", category: ["음식점", "레스토랑"] },
     // ... 더 많은 가게 데이터
   ];
+  const [, setSelectedClassification] = useState(221);
 
   // server
-  const { data: subClassificationsRes } = useGetSubClassifications();
-
-  const classificationName =
-    subClassificationsRes?.map((item) => ({
-      name: item.name,
-    })) || [];
+  // const { data: subClassificationsRes } = useGetSubClassifications();
+  const { data: classificationsRes } = useGetClassifications();
 
   return (
     <div className="flex mt-24">
@@ -28,7 +26,12 @@ const RentalOfficePage = () => {
         <Card />
       </div>
       <div>
-        <LocationClassificationBtn classifications={classificationName} />
+        {classificationsRes && (
+          <LocationClassificationBtn
+            classifications={classificationsRes}
+            setSelectedClassification={setSelectedClassification}
+          />
+        )}
         <div>
           <div className="font-bold	text-24 mt-64 ml-5 mb-16">신촌</div>
           <div className="grid  grid-cols-3 grid-flow-row gap-4 lg:grid-cols-2">

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -1,6 +1,7 @@
 import LocationClassificationBtn from "@/components/atoms/LocationClassificationBtn";
 import Card from "@/components/organisms/Card";
 import Store from "@/components/molecules/Store";
+import { useGetSubClassifications } from "@/hooks/queries/storeQueries";
 
 const RentalOfficePage = () => {
   const storeData = [
@@ -12,13 +13,22 @@ const RentalOfficePage = () => {
     { title: "또 다른 가게 이름", category: ["음식점", "레스토랑"] },
     // ... 더 많은 가게 데이터
   ];
+
+  // server
+  const { data: subClassificationsRes } = useGetSubClassifications();
+
+  const classificationName =
+    subClassificationsRes?.map((item) => ({
+      name: item.name,
+    })) || [];
+
   return (
     <div className="flex mt-24">
       <div className="flex mr-24 md:hidden">
         <Card />
       </div>
       <div>
-        <LocationClassificationBtn text={["신촌", "연희동", "연세대학교", "한양대학교"]} />
+        <LocationClassificationBtn classifications={classificationName} />
         <div className="font-bold	text-24 mt-64 ml-5 mb-16">신촌</div>
         <div className="grid  grid-cols-3 grid-flow-row gap-4 lg:grid-cols-2">
           {storeData.map((store, index) => (

--- a/src/components/templates/common/MainLayout.tsx
+++ b/src/components/templates/common/MainLayout.tsx
@@ -3,14 +3,17 @@ import { Outlet } from "react-router-dom";
 
 const MainLayout = () => {
   return (
-    <>
-      <HeaderContainer />
+    <div className="relative">
+      <div className="relative z-10">
+        <HeaderContainer />
+      </div>
+
       {/* <Nav /> */}
       <div className="flex-1 flex flex-col">
         <Outlet />
       </div>
       {/* <Footer /> */}
-    </>
+    </div>
   );
 };
 

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import qs from "qs";
 
 export const $axios = axios.create({
-  baseURL: "http://43.202.94.218:8080",
+  baseURL: import.meta.env.VITE_UPBRELLA_API_BASE_URL,
   timeout: 15000,
   paramsSerializer: (params) => {
     return qs.stringify(params, { arrayFormat: "repeat" });

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import qs from "qs";
 
 export const $axios = axios.create({
-  baseURL: import.meta.env.VITE_UPBRELLA_API_BASE_URL,
+  baseURL: "http://43.202.94.218:8080",
   timeout: 15000,
   paramsSerializer: (params) => {
     return qs.stringify(params, { arrayFormat: "repeat" });

--- a/src/types/commonTypes.ts
+++ b/src/types/commonTypes.ts
@@ -14,6 +14,12 @@ export type TRoute = {
   component: () => JSX.Element;
 };
 
+// 모바일 메뉴 type
+export type TMobileMenu = {
+  name: string;
+  path: string;
+};
+
 // 테이블 column type
 export type TTableColumn<T> = {
   id: T;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,8 +19,8 @@ export default {
       borderRadius: px0_1000,
       fontSize: px0_100,
       lineHeight: px0_100,
-      padding: px0_100,
-      margin: px0_100,
+      padding: px0_1000,
+      margin: px0_1000,
       colors: {
         "primary-700": "#E05938",
         "primary-600": "#E86546",


### PR DESCRIPTION
### PR Type

- [x] 기능 개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update) (formatting, local variables)
- [x] 화면 작업 (Style, CSS)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 버그수정 (Bugfix)
- [ ] 빌드, 배포 관련 변경 (Build, Deploy)
- [ ] 문서 작업 (Docs)
- [ ] 그 외 (ETC)

## 작업 내용
- 대여지점 대분류, 소분류 api 확인
- 모바일(테블렛, 폰) 헤더 메뉴 생성
- 로그인/로그아웃에 따른 메뉴 생성

## Before

## After
- 모바일 헤더(로그아웃)
<img width="683" alt="스크린샷 2023-08-31 오전 8 28 47" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/719ca29c-0037-4d53-930d-9f237ffb878e">


- 모바일 헤더(로그인)
<img width="681" alt="스크린샷 2023-08-31 오전 8 29 25" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/76cad046-c68d-491b-9e9d-58ec860eaa53">

## To Reviewers (참고 사항, 첨부 자료 등)
- 현재 네이버지도가 배포환경에서는 뜨는데 localhost에서 인증이 실패해 제대로 된 테스트가 안되고있습니다! 금방 해결해서 관련 api 통신 후 pr 올리겠습니다.
- 협업 지점 상세 api는 이미지가 누락되어있어서 api 명세  재확인을 부탁드렸습니다.
- 소분류 태그별 api 보다는 전체 협업지점 목록을 받아야 디자인대로 개발할 수 있을 것 같아 백엔드 개발자분께 문의드렸습니다
- 모바일 헤더 메뉴에서 로그인여부는 props를 통해 임의 설정했습니다.
