### PR TITLE
feat: 폼 URL 연결, 예외 처리 

### DIFF
--- a/src/components/pages/home/HomeMainPage.tsx
+++ b/src/components/pages/home/HomeMainPage.tsx
@@ -9,7 +9,8 @@ const navItems = [
   },
   {
     name: "반납폼",
-    path: "/return",
+    path: "/return/form?storeId=1",
+    // TODO path: "/return/form", 메인 화면에서 접속을 위해 임시로 storeId 넣어둠
   },
   {
     name: "로그인",

--- a/src/components/pages/rent/index.tsx
+++ b/src/components/pages/rent/index.tsx
@@ -19,8 +19,23 @@ const RentPage = () => {
   // 대여 전(false), 대여 후(true)
   const [isRent, setIsRent] = useState(false);
 
+  const url = window.location.href;
+  const match = url.match(/\/rent\/form\/(\d+)/);
+  const id = match ? match[1] : null;
+
+  const umbrellaId = parseInt(id, 10);
+
   // url에서 UmbrellaId 가져옴
-  const umbrellaId = 1; // TODO: 일단 고정값으로 두었는데, qr코드 url 협의후에 수정
+
+  // useEffect(() => {
+  //   console.log(id);
+
+  //   if (id) {
+  //     setUmbrellaId(parseInt(id, 10));
+  //     console.log(id);
+  //     console.log(umbrellaId);
+  //   }
+  // }, [id]);
 
   // 대여폼
   const [name, setName] = useState("");

--- a/src/components/pages/rent/index.tsx
+++ b/src/components/pages/rent/index.tsx
@@ -7,13 +7,14 @@ import { useEffect, useState } from "react";
 import RentModalAccount from "@/components/atoms/Form/RentModalAccount";
 import RentModalFinish from "@/components/atoms/Form/RentModalFinish";
 import FormModal from "@/components/molecules/FormModal";
-import { useGetRentFormData } from "@/hooks/queries/formQueries";
+import { useGetRentFormData, useGetReturnUmbrella } from "@/hooks/queries/formQueries";
 import { loginInfo } from "@/recoil";
 import { useRecoilValue } from "recoil";
 import { formatPhoneNumber } from "@/utils/utils";
 import { useMutation } from "react-query";
 import { postRent } from "@/api/formApi";
 import { toast } from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
 
 const RentPage = () => {
   // 대여 전(false), 대여 후(true)
@@ -23,19 +24,8 @@ const RentPage = () => {
   const match = url.match(/\/rent\/form\/(\d+)/);
   const id = match ? match[1] : null;
 
-  const umbrellaId = parseInt(id, 10);
-
-  // url에서 UmbrellaId 가져옴
-
-  // useEffect(() => {
-  //   console.log(id);
-
-  //   if (id) {
-  //     setUmbrellaId(parseInt(id, 10));
-  //     console.log(id);
-  //     console.log(umbrellaId);
-  //   }
-  // }, [id]);
+  const umbrellaId = id ? parseInt(id, 10) : 0;
+  const navigate = useNavigate();
 
   // 대여폼
   const [name, setName] = useState("");
@@ -56,7 +46,18 @@ const RentPage = () => {
   }, [userInfo]);
 
   // 대여 폼 데이터 조회 (location, storeName, umbrellaNo)
-  const { data } = useGetRentFormData(umbrellaId);
+  const { data, isError } = useGetRentFormData(umbrellaId);
+  if (isError) {
+    // TODO Not-found URL 형식
+    navigate("/404");
+    toast.error("존재하지 않는 우산 고유 번호입니다.");
+  }
+
+  const { data: umbrellaData } = useGetReturnUmbrella();
+  if (umbrellaData) {
+    navigate("/404");
+    toast.error("이미 대여중인 우산이 있습니다.");
+  }
 
   useEffect(() => {
     if (data) {

--- a/src/components/pages/rent/index.tsx
+++ b/src/components/pages/rent/index.tsx
@@ -14,16 +14,12 @@ import { formatPhoneNumber } from "@/utils/utils";
 import { useMutation } from "react-query";
 import { postRent } from "@/api/formApi";
 import { toast } from "react-hot-toast";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 const RentPage = () => {
   // 대여 전(false), 대여 후(true)
   const [isRent, setIsRent] = useState(false);
-
-  const url = window.location.href;
-  const match = url.match(/\/rent\/form\/(\d+)/);
-  const id = match ? match[1] : null;
-
+  const { id } = useParams();
   const umbrellaId = id ? parseInt(id, 10) : 0;
   const navigate = useNavigate();
 

--- a/src/components/pages/rent/index.tsx
+++ b/src/components/pages/rent/index.tsx
@@ -27,6 +27,8 @@ const RentPage = () => {
   const umbrellaId = id ? parseInt(id, 10) : 0;
   const navigate = useNavigate();
 
+  const [isLoading, setIsLoading] = useState(false);
+
   // 대여폼
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
@@ -46,8 +48,13 @@ const RentPage = () => {
   }, [userInfo]);
 
   // 대여 폼 데이터 조회 (location, storeName, umbrellaNo)
-  const { data, isError } = useGetRentFormData(umbrellaId);
+  const { data, isError, isLoading: rentFormDataLoading } = useGetRentFormData(umbrellaId);
+  if (rentFormDataLoading) {
+    setIsLoading(true);
+  }
+
   if (isError) {
+    setIsLoading(false);
     // TODO Not-found URL 형식
     navigate("/404");
     toast.error("존재하지 않는 우산 고유 번호입니다.");
@@ -61,6 +68,7 @@ const RentPage = () => {
 
   useEffect(() => {
     if (data) {
+      setIsLoading(false);
       setRegion(data.classificationName);
       setStoreName(data.rentStoreName);
       setUmbrellaUuid(data.umbrellaUuid);
@@ -99,7 +107,9 @@ const RentPage = () => {
   const [isOpenLockPwModal, setIsOpenLockPwModal] = useState(false); // 자물쇠 비밀번호 안내 모달
   const handleCloseLockPwModal = () => setIsOpenLockPwModal(false);
 
-  return (
+  return isLoading ? (
+    <div>Loading...</div>
+  ) : (
     <div className="flex-col max-w-2xl mx-auto">
       <MobileHeader />
       <div className="mt-20 text-24 font-semibold leading-32 text-black">

--- a/src/components/pages/rent/index.tsx
+++ b/src/components/pages/rent/index.tsx
@@ -27,8 +27,6 @@ const RentPage = () => {
   const umbrellaId = id ? parseInt(id, 10) : 0;
   const navigate = useNavigate();
 
-  const [isLoading, setIsLoading] = useState(false);
-
   // 대여폼
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
@@ -50,11 +48,11 @@ const RentPage = () => {
   // 대여 폼 데이터 조회 (location, storeName, umbrellaNo)
   const { data, isError, isLoading: rentFormDataLoading } = useGetRentFormData(umbrellaId);
   if (rentFormDataLoading) {
-    setIsLoading(true);
+    // TODO - Loading 화면 만들기
+    <div>Loading</div>;
   }
 
   if (isError) {
-    setIsLoading(false);
     // TODO Not-found URL 형식
     navigate("/404");
     toast.error("존재하지 않는 우산 고유 번호입니다.");
@@ -68,7 +66,6 @@ const RentPage = () => {
 
   useEffect(() => {
     if (data) {
-      setIsLoading(false);
       setRegion(data.classificationName);
       setStoreName(data.rentStoreName);
       setUmbrellaUuid(data.umbrellaUuid);
@@ -107,9 +104,7 @@ const RentPage = () => {
   const [isOpenLockPwModal, setIsOpenLockPwModal] = useState(false); // 자물쇠 비밀번호 안내 모달
   const handleCloseLockPwModal = () => setIsOpenLockPwModal(false);
 
-  return isLoading ? (
-    <div>Loading...</div>
-  ) : (
+  return (
     <div className="flex-col max-w-2xl mx-auto">
       <MobileHeader />
       <div className="mt-20 text-24 font-semibold leading-32 text-black">

--- a/src/components/pages/return/index.tsx
+++ b/src/components/pages/return/index.tsx
@@ -32,8 +32,17 @@ const ReturnPage = () => {
   const returnStoreId = storeId ? parseInt(storeId, 10) : 0;
 
   // 반납 폼 데이터 조회 (classificationName, rentStoreName)
-  const { data: formData, isError: getReturnformError } = useGetReturnFormData(returnStoreId);
-  if (getReturnformError) {
+  const {
+    data: formData,
+    isLoading: returnFormDataLoading,
+    isError: getReturnFormError,
+  } = useGetReturnFormData(returnStoreId);
+
+  if (returnFormDataLoading) {
+    <div>Loading..</div>;
+  }
+
+  if (getReturnFormError) {
     navigate("/404");
     toast.error("존재하지 않는 협업 지점 고유번호입니다.");
   }

--- a/src/components/pages/return/index.tsx
+++ b/src/components/pages/return/index.tsx
@@ -16,6 +16,7 @@ import { formatPhoneNumber } from "@/utils/utils";
 import { useMutation } from "react-query";
 import { toast } from "react-hot-toast";
 import { patchReturn } from "@/api/formApi";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const ReturnPage = () => {
   // 반납전(false), 반납후(true)
@@ -23,6 +24,19 @@ const ReturnPage = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [isActive, setIsActive] = useState(false);
+  const navigate = useNavigate();
+
+  // TODO url (storeId)
+  const location = useLocation();
+  const storeId = new URLSearchParams(location.search).get("storeId");
+  const returnStoreId = storeId ? parseInt(storeId, 10) : 0;
+
+  // 반납 폼 데이터 조회 (classificationName, rentStoreName)
+  const { data: formData, isError: getReturnformError } = useGetReturnFormData(returnStoreId);
+  if (getReturnformError) {
+    navigate("/404");
+    toast.error("존재하지 않는 협업 지점 고유번호입니다.");
+  }
 
   // 로그인 유저 정보 조회 (이름, 전화번호, 은행명, 계좌번호)
   const userInfo = useRecoilValue(loginInfo);
@@ -44,11 +58,6 @@ const ReturnPage = () => {
   const [improvementReportContent, setImprovementReportContent] = useState("");
   const [elapsedDay, setElapsedDay] = useState(0);
 
-  // TODO url (storeId)
-  const returnStoreId = 1;
-
-  // 반납 폼 데이터 조회 (classificationName, rentStoreName)
-  const { data: formData } = useGetReturnFormData(returnStoreId);
   useEffect(() => {
     if (formData) {
       setClassificationName(formData.classificationName);
@@ -57,7 +66,12 @@ const ReturnPage = () => {
   }, [formData]);
 
   // 사용자가 빌린 우산 조회 (umbrellaUuid, 대여일수)
-  const { data: umbrellaData } = useGetReturnUmbrella();
+  const { data: umbrellaData, isError: getUmbrellaError } = useGetReturnUmbrella();
+  if (getUmbrellaError) {
+    navigate("/404");
+    toast.error("사용자가 빌린 우산이 없습니다.");
+  }
+
   useEffect(() => {
     if (umbrellaData) {
       setUmbrellaUuid(umbrellaData.uuid);

--- a/src/hooks/queries/formQueries.ts
+++ b/src/hooks/queries/formQueries.ts
@@ -5,6 +5,7 @@ export const useGetRentFormData = (umbrellaId: number) => {
     queryKey: ["rentFormData"],
     queryFn: () => getRentFormData(umbrellaId),
     select: (res) => res.data,
+    retry: 0,
   });
 };
 
@@ -13,6 +14,7 @@ export const useGetReturnFormData = (storeId: number) => {
     queryKey: ["returnFormData"],
     queryFn: () => getReturnFormData(storeId),
     select: (res) => res.data,
+    retry: 0,
   });
 };
 
@@ -21,5 +23,6 @@ export const useGetReturnUmbrella = () => {
     queryKey: ["returnUmbrella"],
     queryFn: () => getReturnUmbrella(),
     select: (res) => res.data,
+    retry: 0,
   });
 };

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -14,7 +14,7 @@ export const NOT_LAYOUT_ROUTES: TRoute[] = [
   },
   {
     name: "반납폼 페이지",
-    path: "/return",
+    path: "/return/form",
     component: ReturnPage,
   },
 ];

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -9,7 +9,7 @@ import { TRoute } from "@/types/commonTypes";
 export const NOT_LAYOUT_ROUTES: TRoute[] = [
   {
     name: "대여폼 페이지",
-    path: "rent/form/:umbrellaId",
+    path: "rent/form/:id",
     component: RentPage,
   },
   {


### PR DESCRIPTION
### PR Type

- [x] 기능 개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update) (formatting, local variables)
- [ ] 화면 작업 (Style, CSS)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 버그수정 (Bugfix)
- [ ] 빌드, 배포 관련 변경 (Build, Deploy)
- [ ] 문서 작업 (Docs)
- [ ] 그 외 (ETC)

## 작업 내용
- 대여폼, 반납폼 URL 형식에 맞춰 대여폼에서는 umbrellaId, 반납폼에서는 storeId 연결 
- URL 예외처리 (잘못된 URL 접속, 대여한 우산이 없는데 반납폼에 들어온 경우, 이미 우산을 대여중인데 대여폼에 들어온 경우, umbrellId, storeId가 DB에 없는 경우 => NotFound 이동)

## Before
storeId가 존재하지 않는 협업지점 고유번호인 경우

<img width="250" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76530562/982bbcca-e4c2-4e92-aa8b-2e182719b499">

## After
<img width="250" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76530562/f3e81840-311c-449e-ba57-80054967e911">
<img width="250" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76530562/47c97bdd-409d-490f-9e19-90a3ba6c5db2">


## To Reviewers (참고 사항, 첨부 자료 등)
1. 일단은 URL 예외를 같은 NotFound page로 매핑하고 URL은 /404 로 변경하였는데 처리 방식에 대해서는 논의 후 결정하면 좋을 것 같습니다.
2. URL 예외의 경우 바로 에러 페이지로 이동하는게 좋다고 판단하여 useQuery에서 retry을 0으로 설정해두었습니다. 
3. 메인페이지에서 이동할 때는 대여폼-umbrellaId:1, 반납폼-storeId:1로 임의로 설정해두었습니다. 