### PR TITLE
feat: 협업지점 소개 페이지 전체 리스트 조회 및 스크롤 이동

### DIFF
--- a/src/api/storeApi.ts
+++ b/src/api/storeApi.ts
@@ -14,7 +14,7 @@ import {
 } from "@/types/admin/StoreTypes";
 
 const API = {
-  ADMIN_STORES: (id?: number) => (id ? `/admin/stores/${id}` : `/stores`),
+  ADMIN_STORES: (id?: number) => (id ? `/admin/stores/${id}` : `/admin/stores`),
   ADMIN_IMAGE_UPLOAD: (id: number) => `/admin/stores/${id}/images`,
   ADMIN_IMAGE_DELETE: (id: number) => `/admin/stores/images/${id}`,
   ADMIN_CLASSIFICATIONS: (id?: number) =>

--- a/src/api/storeApi.ts
+++ b/src/api/storeApi.ts
@@ -14,9 +14,9 @@ import {
 } from "@/types/admin/StoreTypes";
 
 const API = {
-  ADMIN_STORES: (id?: number) => (id ? `/stores/${id}` : `/stores`),
-  ADMIN_IMAGE_UPLOAD: (id: number) => `/stores/${id}/images`,
-  ADMIN_IMAGE_DELETE: (id: number) => `/stores/images/${id}`,
+  ADMIN_STORES: (id?: number) => (id ? `/admin/stores/${id}` : `/stores`),
+  ADMIN_IMAGE_UPLOAD: (id: number) => `/admin/stores/${id}/images`,
+  ADMIN_IMAGE_DELETE: (id: number) => `/admin/stores/images/${id}`,
   ADMIN_CLASSIFICATIONS: (id?: number) =>
     id ? `/stores/classifications/${id}` : "/stores/classifications/",
   CLASSIFICATIONS: () => "/stores/classifications",

--- a/src/api/storeApi.ts
+++ b/src/api/storeApi.ts
@@ -18,10 +18,10 @@ const API = {
   ADMIN_IMAGE_UPLOAD: (id: number) => `/admin/stores/${id}/images`,
   ADMIN_IMAGE_DELETE: (id: number) => `/admin/stores/images/${id}`,
   ADMIN_CLASSIFICATIONS: (id?: number) =>
-    id ? `/stores/classifications/${id}` : "/stores/classifications/",
+    id ? `/admin/stores/classifications/${id}` : "/admin/stores/classifications/",
   CLASSIFICATIONS: () => "/stores/classifications",
   ADMIN_SUBCLASSIFICATIONS: (id?: number) =>
-    id ? `/stores/subClassifications/${id}` : "/stores/subClassifications",
+    id ? `/admin/stores/subClassifications/${id}` : "/admin/stores/subClassifications",
   STORE_CLASSIFICATIONS: (id: number) => `/stores/classification/${id}`,
   STORE_LIST: () => "/stores/introductions",
   STORE_DETAIL: (id: number) => `/stores/${id}`,

--- a/src/api/storeApi.ts
+++ b/src/api/storeApi.ts
@@ -9,27 +9,29 @@ import {
   TStoreParams,
   TStoreImageParams,
   TClassificationAllStore,
+  TStoreListDetail,
+  TStoreListRes,
 } from "@/types/admin/StoreTypes";
 
 const API = {
-  ADMIN_STORES: (id?: number) => (id ? `/admin/stores/${id}` : `/admin/stores`),
-  ADMIN_IMAGE_UPLOAD: (id: number) => `/admin/stores/${id}/images`,
-  ADMIN_IMAGE_DELETE: (id: number) => `/admin/stores/images/${id}`,
+  ADMIN_STORES: (id?: number) => (id ? `/stores/${id}` : `/stores`),
+  ADMIN_IMAGE_UPLOAD: (id: number) => `/stores/${id}/images`,
+  ADMIN_IMAGE_DELETE: (id: number) => `/stores/images/${id}`,
   ADMIN_CLASSIFICATIONS: (id?: number) =>
-    id ? `/admin/stores/classifications/${id}` : "/admin/stores/classifications",
+    id ? `/stores/classifications/${id}` : "/stores/classifications/",
   CLASSIFICATIONS: () => "/stores/classifications",
   ADMIN_SUBCLASSIFICATIONS: (id?: number) =>
-    id ? `/admin/stores/subClassifications/${id}` : "/admin/stores/subClassifications",
+    id ? `/stores/subClassifications/${id}` : "/stores/subClassifications",
   STORE_CLASSIFICATIONS: (id: number) => `/stores/classification/${id}`,
   STORE_LIST: () => "/stores/introductions",
   STORE_DETAIL: (id: number) => `/stores/${id}`,
 } as const;
 
-// // 협업지점 소개 페이지에서의 협업지점 목록 조회
-// export const getStoreList = async () => {
-//   const res = await $axios.get<TApiResponse<TStoreListRes>>(API.STORE_LIST());
-//   return res.data;
-// };
+// 협업지점 소개 페이지에서의 협업지점 목록 조회
+export const getStoreList = async () => {
+  const res = await $axios.get<TApiResponse<TStoreListRes>>(API.STORE_LIST());
+  return res.data;
+};
 
 // 협업지점 전체 조회
 export const getStores = async () => {
@@ -37,11 +39,11 @@ export const getStores = async () => {
   return res.data;
 };
 
-// // 협업지점 상세 조회
-// export const getStoreDetail = async (id: number) => {
-//   const res = await $axios.get<TApiResponse<TStoreListDetail>>(API.STORE_DETAIL(id));
-//   return res.data;
-// };
+// 협업지점 상세 조회
+export const getStoreDetail = async (id: number) => {
+  const res = await $axios.get<TApiResponse<TStoreListDetail>>(API.STORE_DETAIL(id));
+  return res.data;
+};
 
 // 협업지점 이미지 업로드
 
@@ -78,7 +80,7 @@ export const deleteStoreImage = async (storeId: number) => {
 
 // 대분류 태그
 export const getClassifications = async () => {
-  const res = await $axios.get<TApiResponse<TClassificationAllRes>>(API.CLASSIFICATIONS());
+  const res = await $axios.get<TApiResponse<TClassificationAllRes>>(API.ADMIN_CLASSIFICATIONS());
   return res.data;
 };
 

--- a/src/components/atoms/LocationClassificationBtn/index.tsx
+++ b/src/components/atoms/LocationClassificationBtn/index.tsx
@@ -6,6 +6,7 @@ export type TLocationClassificationBtn = {
   map?: naver.maps.Map;
   setSelectedClassificationId?: (id: number) => void;
   setSelectedClassificationName?: (name: string) => void;
+  handleClassificationSelection?: (id: number) => void;
 };
 
 const LocationClassificationBtn = ({
@@ -13,6 +14,7 @@ const LocationClassificationBtn = ({
   map,
   setSelectedClassificationId,
   setSelectedClassificationName,
+  handleClassificationSelection,
 }: TLocationClassificationBtn) => {
   const [activeIndex, setActiveIndex] = useState(0);
   const buttonsRef = useRef<(HTMLButtonElement | null)[]>([]);
@@ -26,10 +28,10 @@ const LocationClassificationBtn = ({
   const handleClick = (index: number, classificationId: number, classificationName: string) => {
     if (activeIndex !== index) {
       setActiveIndex(index);
-
+      handleClassificationSelection?.(index);
       const location = classifications[index];
 
-      if (map && window.naver && window.naver.maps && isTClassification(location)) {
+      if (map instanceof window.naver.maps.Map && isTClassification(location)) {
         const newCenter = new window.naver.maps.LatLng(
           location.latitude ?? 0,
           location.longitude ?? 0
@@ -46,7 +48,7 @@ const LocationClassificationBtn = ({
     <div>
       {classifications.map((item, index) => (
         <button
-          key={item.name}
+          key={item.id}
           ref={(el) => (buttonsRef.current[index] = el)}
           className={`${
             activeIndex === index

--- a/src/components/atoms/LocationClassificationBtn/index.tsx
+++ b/src/components/atoms/LocationClassificationBtn/index.tsx
@@ -1,31 +1,43 @@
-import { TClassification } from "@/types/admin/StoreTypes";
-import { useState } from "react";
+import { TClassification, TSubClassification } from "@/types/admin/StoreTypes";
+import { useRef, useState } from "react";
 
 export type TLocationClassificationBtn = {
-  classifications: TClassification[];
-  handleClassificationSelection: (classificationId: number) => void;
+  classifications: (TClassification | TSubClassification)[];
   map?: naver.maps.Map;
+  setSelectedClassificationId?: (id: number) => void;
+  setSelectedClassificationName?: (name: string) => void;
 };
 
 const LocationClassificationBtn = ({
   classifications,
   map,
-  handleClassificationSelection,
+  setSelectedClassificationId,
+  setSelectedClassificationName,
 }: TLocationClassificationBtn) => {
   const [activeIndex, setActiveIndex] = useState(0);
+  const buttonsRef = useRef<(HTMLButtonElement | null)[]>([]);
 
-  const handleClick = (index: number, classificationId: number) => {
+  const isTClassification = (
+    item: TClassification | TSubClassification | null
+  ): item is TClassification => {
+    return item !== null && item.type === "CLASSIFICATION";
+  };
+
+  const handleClick = (index: number, classificationId: number, classificationName: string) => {
     if (activeIndex !== index) {
       setActiveIndex(index);
-      handleClassificationSelection(classificationId);
 
-      if (map && window.naver && window.naver.maps) {
-        const location = classifications[index];
+      const location = classifications[index];
+
+      if (map && window.naver && window.naver.maps && isTClassification(location)) {
         const newCenter = new window.naver.maps.LatLng(
           location.latitude ?? 0,
           location.longitude ?? 0
         );
-        map.setCenter(newCenter);
+        map?.setCenter(newCenter);
+      } else if (classificationId && setSelectedClassificationId && setSelectedClassificationName) {
+        setSelectedClassificationId(classificationId);
+        setSelectedClassificationName(classificationName);
       }
     }
   };
@@ -35,12 +47,13 @@ const LocationClassificationBtn = ({
       {classifications.map((item, index) => (
         <button
           key={item.name}
+          ref={(el) => (buttonsRef.current[index] = el)}
           className={`${
             activeIndex === index
               ? "text-primary-500 border-primary-500"
               : "text-gray-700 border-gray-300"
           } font-semibold px-16 py-8 mr-8 rounded-999 border text-15 bg-white`}
-          onClick={() => handleClick(index, item.id)}
+          onClick={() => handleClick(index, item.id, item.name)}
         >
           {item.name}
         </button>

--- a/src/components/molecules/Store/index.stories.tsx
+++ b/src/components/molecules/Store/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryFn } from "@storybook/react";
-import Store, { TStore } from "@/components/molecules/Store/index";
+import Store, { TStoreProps } from "@/components/molecules/Store/index";
 
 export default {
   title: "molecules/Store",
@@ -7,7 +7,30 @@ export default {
   tags: ["autodocs"],
 } as Meta;
 
-const Template: StoryFn<TStore> = (args) => <Store {...args} />;
+const Template: StoryFn<TStoreProps> = (args) => <Store {...args} />;
 
 export const Default = Template.bind({});
-Default.args = { title: "모티스 스터디카페", category: ["카페", "디저트"] };
+
+Default.args = {
+  storeList: [
+    {
+      subClassificationId: 1,
+      stores: [
+        {
+          id: 1,
+          thumbnail:
+            "https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Ft1.daumcdn.net%2Fcfile%2Ftistory%2F275666475594CA3102",
+          name: "ㅇㅇ",
+          category: "ㅇㅇ",
+        },
+        {
+          id: 2,
+          thumbnail:
+            "https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Ft1.daumcdn.net%2Fcfile%2Ftistory%2F275666475594CA3102",
+          name: "ㅇㅇ",
+          category: "ㅇㅇ",
+        },
+      ],
+    },
+  ],
+};

--- a/src/components/molecules/Store/index.tsx
+++ b/src/components/molecules/Store/index.tsx
@@ -1,22 +1,84 @@
-export type TStore = {
-  title: string;
-  category: string[];
+import { TStoreListAll, TSubClassification } from "@/types/admin/StoreTypes";
+import { useEffect, useRef } from "react";
+
+export type TStoreProps = {
+  storeList: TStoreListAll[];
+  classifications?: TSubClassification[];
+  setSelectedStoreId?: (storeId: number) => void;
+  selectedClassificationId?: number;
+  selectedClassificationName?: string; // 선택한 분류 이름을 받음
 };
 
-const Store = ({ title, category }: TStore) => {
-  return (
-    <div className="flex mb-12">
-      <div className="flex flex-col items-center">
-        <img
-          src="https://m.godshop.co.kr/web/product/big/202011/b472f812f7bb5cdaa048439de5f0360f.jpg"
-          alt="Image"
-          className="w-248 h-174 rounded-12"
-        />
+const Store = ({
+  storeList,
+  classifications,
+  setSelectedStoreId,
+  selectedClassificationName,
+}: TStoreProps) => {
+  const classificationRefs = useRef<(HTMLDivElement | null)[]>([]);
 
-        <div className="text-gray-700 text-16 font-semibold mt-12">{title}</div>
-        <div className="text-gray-600 text-12">{category.join(", ")}</div>
-      </div>
-    </div>
+  useEffect(() => {
+    if (selectedClassificationName && classifications) {
+      const index = classifications.findIndex(
+        (classification) => classification.name === selectedClassificationName
+      );
+      if (index !== -1 && classificationRefs.current[index]) {
+        const element = classificationRefs.current[index];
+        if (element) {
+          element.scrollIntoView({ behavior: "smooth" }); // 스무스한 스크롤
+        }
+      }
+    }
+  }, [selectedClassificationName, classifications]);
+
+  return (
+    <>
+      {storeList.map((store, index) => (
+        <div key={index}>
+          <div
+            ref={(el) => (classificationRefs.current[index] = el)}
+            className="font-bold text-24 mt-64 ml-5 mb-16"
+          >
+            {classifications
+              ? classifications.find(
+                  (classification) => classification.id === store.subClassificationId
+                )?.name
+              : ""}
+          </div>
+          <div className="grid grid-cols-3 grid-flow-row gap-4 lg:grid-cols-2">
+            {store.stores.map((storeItem, itemIndex) => (
+              <div
+                className="flex mb-12"
+                key={itemIndex}
+                onClick={() => {
+                  if (storeItem && storeItem.id && setSelectedStoreId) {
+                    setSelectedStoreId(storeItem.id);
+                  }
+                }}
+              >
+                <div className="flex flex-col items-center">
+                  {storeItem.thumbnail ? (
+                    <img
+                      src={`${storeItem.thumbnail}`}
+                      alt="Image"
+                      className="w-248 h-174 rounded-12"
+                    />
+                  ) : (
+                    <img
+                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAATcAAACiCAMAAAATIHpEAAAAwFBMVEUNDQ3///9UxQMAAAAICAhdXV1RvwMYGBjr6+sAAA3Ly8vBwcHd3d2ampqsrKyAgIBWywFlZWWOjo4uZwn4+Ph0dHTQ0NAwbQkycgmPj481NTWhoaHm5uaysrLy8vLW1tZPT09FwQBlyTE2ewg4gAglJSUsLCw/Pz9FRUUbGxt4eHhMTExXV1dsbGwrXwlyzULY8cjQ7rvi9dS15Jru+eaH1VlgyCOY2XfF6q9wzT/v+eeq4IyC0lna8c6t4JaK1WYVU2AwAAADtklEQVR4nO3b21baQBSAYchQMVJEEbCAVEMVPHNQDtbT+79VgUJmBwYySS+Q5v/W6kUHajP/2gECmEoBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiEn5TGuZ7R3YF1ctzlX9JVVYLFZrhDPKpNK+m0Uj9dNf+6Y2/vPEkt2yfrd9uoWgWzx0i4du8dAtHrrFQ7d46BZPYrtl/u0iMiHdVPAqfNrsqnWVXW2nTJfrhtVkdFP1w7lGW01GrX14NttdqVLMBjao8v4dr/UN6r6xWC3OVxPSTV5wK3Wo95wuFeTIqe/+DceiW8FfPUhWN7mhmv7LTE6Eo1uA2NB9u5RekhOF6CbJDelT1lf0N0m3ALGhpZN0pnS12CXdApSplpCnm1FYt326GYV1S7fm26RbQLDbwUMtWyufy6UC3UwC3crTq6vJn6pYq9PNRHYr+I9lDb3YoJuJ2NCZfq12o7eeo5uJ2FBd5NAPcXQzEhsqixz6RKWbkXlDqk63zdZ0y9NtM7rFQ7d46BZPnG4P4o5Full3KxifeOkW1u1Q3DFHN+tu+oIso/RHEnQzd6voHLdq9X50S5m7Hegcpdb00/mMUsd6jW4pczf5kXQ631ZKXTTkEt3M3W7TAaWfS5+20s3crZXejG7GbvI9ObpF6VY21eJ1SFi3wCuRhTOuT8O73ax876bUoltot5S6Xgq3307u+yHGX9Qzd5tMXOBUzU1ewyW2W+5grnIn31arLFbrcptK3fsX8rkLlUmph5U7ZlLn/o/U3fR/c/FfdLP+urO+oVYuFgt3+nvUy3fMmH63ee0PTI5k7x4AAAAAEsjd9gHsJvdk20ewk9wTZ9uHsIvcx6O9bR/DDppkc+gWmXty5NAtsum00S2y2bTRLaq/00a3iObTRrdo/Gx0i0Jno1sE7qmfjW72xLTRzZ6cNrpZC0wb3WwFp41ulpaz0c3KSja62VjNRjcLhmx0C+f+WM1Gt1Bi2rwO3WzpafO6nZ7n0c2KyNbv9PvdJ7rZEI9tXvO5+TwY0s2CzDYav/weNHl8syCfSYev3f4bzws23F86m/fe7PX8aZvY9sF9XfIkHfSePj9EtqPTbR/dlxV4bOv0xj1PZuP7SGvIk/Rz1HseOGSzoKet6Y2euqO3F7JZ0NPmvb9+fAzH8iQ9Idsa8iQddkfj7pBpsyCyea+j5vsn02ZDTpsz6vc7e2SzEMjmeM7YIZsF99LwNiXZwgSnjWyWmLZYmLZYNk7bI9nWIFss7qWzt46znO0P0C5RpYuDlLsAAAAASUVORK5CYII="
+                      alt="Image"
+                      className="w-248 h-174 rounded-12"
+                    />
+                  )}
+                  <div className="text-gray-700 text-16 font-semibold mt-12">{storeItem.name}</div>
+                  <div className="text-gray-600 text-12">{storeItem.category}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
   );
 };
 

--- a/src/components/organisms/Card/index.tsx
+++ b/src/components/organisms/Card/index.tsx
@@ -1,10 +1,14 @@
-import ImgSwiper from "../ImgSwiper";
-import RentalInfoCard from "../RentalInfoCard";
+import ImgSwiper from "@/components/organisms/ImgSwiper/index";
+import RentalInfoCard from "@/components/organisms/RentalInfoCard/index";
+// import { TStoreListDetail } from "@/types/admin/StoreTypes";
 
+// export type TCard = {
+//   storeDetail: TStoreListDetail;
+// };
 const Card = () => {
   return (
-    <div className="flex flex-col">
-      <ImgSwiper />
+    <div className="flex-col">
+      <ImgSwiper maxWidth={400} maxHeight={280} />
       <RentalInfoCard />
     </div>
   );

--- a/src/components/organisms/ImgSwiper/index.stories.tsx
+++ b/src/components/organisms/ImgSwiper/index.stories.tsx
@@ -1,12 +1,12 @@
 import { StoryFn } from "@storybook/react";
-import ImgSwiper from "@/components/organisms/ImgSwiper/index";
+import ImgSwiper, { TImgSwiper } from "@/components/organisms/ImgSwiper/index";
 
 export default {
   title: "organisms/ImgSwiper",
   component: ImgSwiper,
 };
 
-const Template: StoryFn = (args) => <ImgSwiper {...args} />;
+const Template: StoryFn<TImgSwiper> = (args) => <ImgSwiper {...args} />;
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = { maxWidth: 400, maxHeight: 280 };

--- a/src/components/organisms/ImgSwiper/index.tsx
+++ b/src/components/organisms/ImgSwiper/index.tsx
@@ -6,11 +6,19 @@ import "swiper/css";
 import "swiper/css/navigation";
 import "@/components/organisms/ImgSwiper/styles.css";
 
-const ImgSwiper = () => {
+export type TImgSwiper = {
+  maxWidth?: number;
+  maxHeight?: number;
+};
+
+const ImgSwiper = ({ maxWidth, maxHeight }: TImgSwiper) => {
+  const swiperStyles = {
+    maxWidth: maxWidth ? `${maxWidth}px` : "100%", // maxWidth props에 따라 설정
+    maxHeight: maxHeight ? `${maxHeight}px` : "100%", // maxHeight props에 따라 설정
+  };
   return (
-    <div className="flex justify-start">
+    <div className="flex justify-start" style={swiperStyles}>
       <Swiper
-        className="w-400 h-280 rounded-20"
         modules={[Navigation, Pagination, Scrollbar, A11y]}
         spaceBetween={10}
         slidesPerView={1}

--- a/src/components/organisms/ImgSwiper/styles.css
+++ b/src/components/organisms/ImgSwiper/styles.css
@@ -1,5 +1,6 @@
 .swiper {
   margin-left: 0;
+  border-radius: 20px;
 }
 
 .swiper-button-next::after,

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -2,10 +2,10 @@ import LocationClassificationBtn from "@/components/atoms/LocationClassification
 import Store from "@/components/molecules/Store";
 import Card from "@/components/organisms/Card";
 import { useGetStoreList, useGetSubClassifications } from "@/hooks/queries/storeQueries";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 const RentalOfficePage = () => {
-  const [selectedStoreId, setSelectedStoreId] = useState<number | null>(null);
+  const [, setSelectedStoreId] = useState<number | null>(null);
   const [, setSelectedClassificationId] = useState<number | null>(null);
   const [selectedClassificationName, setSelectedClassificationName] = useState<string>("");
 
@@ -16,12 +16,12 @@ const RentalOfficePage = () => {
   // TODO: 백엔드 404 에러 미해결로 문의드린 상태
   // const { data: useGetStoreDetailData } = useGetStoreDetail(selectedStoreId ?? 16);
 
-  useEffect(() => {
-    // console.log("전체 스토어 리스트", storeListRes);
-    // console.log("전체 카테고리 리스트", subClassificationsRes);
-    // console.log("selected store 아이디", selectedStoreId);
-    // console.log("selected store 정보", useGetStoreDetailData);
-  }, [selectedStoreId]);
+  // useEffect(() => {
+  //   // console.log("전체 스토어 리스트", storeListRes);
+  //   // console.log("전체 카테고리 리스트", subClassificationsRes);
+  //   // console.log("selected store 아이디", selectedStoreId);
+  //   // console.log("selected store 정보", useGetStoreDetailData);
+  // }, [selectedStoreId]);
 
   return (
     <div className="flex mt-24">

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -1,44 +1,53 @@
 import LocationClassificationBtn from "@/components/atoms/LocationClassificationBtn";
-import Card from "@/components/organisms/Card";
 import Store from "@/components/molecules/Store";
-import { useGetClassifications } from "@/hooks/queries/storeQueries";
-import { useState } from "react";
+import Card from "@/components/organisms/Card";
+import { useGetStoreList, useGetSubClassifications } from "@/hooks/queries/storeQueries";
+import { useEffect, useState } from "react";
 
 const RentalOfficePage = () => {
-  const storeData = [
-    { title: "모티스 스터디카페", category: ["카페", "디저트"] },
-    { title: "다른 가게 이름", category: ["카페", "기타"] },
-    { title: "또 다른 가게 이름", category: ["음식점", "레스토랑"] },
-    { title: "모티스 스터디카페", category: ["카페", "디저트"] },
-    { title: "다른 가게 이름", category: ["카페", "기타"] },
-    { title: "또 다른 가게 이름", category: ["음식점", "레스토랑"] },
-    // ... 더 많은 가게 데이터
-  ];
-  const [, setSelectedClassification] = useState(221);
+  const [selectedStoreId, setSelectedStoreId] = useState<number | null>(null);
+  const [, setSelectedClassificationId] = useState<number | null>(null);
+  const [selectedClassificationName, setSelectedClassificationName] = useState<string>("");
 
   // server
-  // const { data: subClassificationsRes } = useGetSubClassifications();
-  const { data: classificationsRes } = useGetClassifications();
+  const { data: subClassificationsRes } = useGetSubClassifications();
+  const { data: storeListRes } = useGetStoreList();
+
+  // TODO: 백엔드 404 에러 미해결로 문의드린 상태
+  // const { data: useGetStoreDetailData } = useGetStoreDetail(selectedStoreId ?? 16);
+
+  useEffect(() => {
+    // console.log("전체 스토어 리스트", storeListRes);
+    // console.log("전체 카테고리 리스트", subClassificationsRes);
+    // console.log("selected store 아이디", selectedStoreId);
+    // console.log("selected store 정보", useGetStoreDetailData);
+  }, [selectedStoreId]);
 
   return (
     <div className="flex mt-24">
       <div className="flex mr-24 md:hidden">
+        {/* {useGetStoreDetailData && <Card storeDetail={useGetStoreDetailData} />} */}
         <Card />
       </div>
       <div>
-        {classificationsRes && (
+        {subClassificationsRes && (
           <LocationClassificationBtn
-            classifications={classificationsRes}
-            handleClassificationSelection={setSelectedClassification}
+            classifications={subClassificationsRes}
+            setSelectedClassificationId={setSelectedClassificationId}
+            setSelectedClassificationName={setSelectedClassificationName}
           />
         )}
         <div>
-          <div className="font-bold	text-24 mt-64 ml-5 mb-16">신촌</div>
-          <div className="grid  grid-cols-3 grid-flow-row gap-4 lg:grid-cols-2">
-            {storeData.map((store, index) => (
-              <Store key={index} title={store.title} category={store.category} />
-            ))}
-          </div>
+          {storeListRes && (
+            <div>
+              <Store
+                storeList={storeListRes}
+                classifications={subClassificationsRes}
+                setSelectedStoreId={setSelectedStoreId}
+                selectedClassificationName={selectedClassificationName}
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/hooks/queries/storeQueries.ts
+++ b/src/hooks/queries/storeQueries.ts
@@ -1,9 +1,12 @@
 import {
   getClassifications,
   getSubClassifications,
-  getClassificationsStore,
   getStores,
+  getStoreList,
+  getClassificationsStore,
+  getStoreDetail,
 } from "@/api/storeApi";
+
 import { useQuery } from "react-query";
 
 export const useGetStores = () => {
@@ -39,12 +42,19 @@ export const useGetClassificationsStore = (classificationId: number) => {
   });
 };
 
-// TODO: 백엔드 api 수정 필요, 수정 후 다시 조회 예정
-// // 협업지점 소개 페이지에서의 협업지점 목록 조회
-// export const useGetStoreList = () => {
-//   return useQuery({
-//     queryKey: ["storeList"],
-//     queryFn: () => getStoreList(),
-//     select: (res) => res.data.storesByClassification,
-//   });
-// };
+// 협업지점 상세조회
+export const useGetStoreDetail = (storeId: number) => {
+  return useQuery(["store", storeId], () => getStoreDetail(storeId), {
+    enabled: storeId !== null, // storeId가 null이면 쿼리 비활성화
+    select: (res) => res.data,
+  });
+};
+
+// 협업지점 소개 페이지에서의 협업지점 목록 조회
+export const useGetStoreList = () => {
+  return useQuery({
+    queryKey: ["storeList"],
+    queryFn: () => getStoreList(),
+    select: (res) => res.data.storesByClassification,
+  });
+};

--- a/src/types/admin/StoreTypes.ts
+++ b/src/types/admin/StoreTypes.ts
@@ -20,9 +20,17 @@ export type TStoreListDetail = {
   id: number;
   name: string;
   category: string;
+  availableUmbrellaCount: number;
+  openStatus: boolean;
+  businessHours: string;
+  contactNumber: string;
+  instaUrl: string;
   address: string;
-  phone: string;
-  opening_hours: string;
+  umbrellaLocation: string;
+  description: string;
+  latitude: number;
+  longitude: number;
+  imageUrls: string[];
 };
 
 // admin 협업지점 조회(전체 조회, 이미 생성된)
@@ -52,7 +60,17 @@ export type TStoreDetail = {
 export type TStoreAllRes = { stores: TStoreDetail[] };
 
 // client 협업지점 목록 조회 response
-export type TStoreListRes = { stores: TStoreListAll[] };
+export type TStoreListRes = { storesByClassification: TStoreListAll[] };
+
+// 대분류 태그 별 협업 지점 목록
+export type TClassificationStore = {
+  id: number;
+  name: string;
+  openStatus: boolean;
+  latitude: number;
+  longitude: number;
+  rentableUmbrellasCount: number;
+};
 
 // api request
 export type TStoreParams = Omit<
@@ -79,16 +97,6 @@ export type TClassification = {
   longitude: number | null;
 };
 
-// 대분류 태그 별 협업 지점 목록
-export type TClassificationStore = {
-  id: number;
-  name: string;
-  openStatus: boolean;
-  latitude: number;
-  longitude: number;
-  rentableUmbrellasCount: number;
-};
-
 export type TStoreImage = {
   id: number;
   imageUrl: string;
@@ -103,11 +111,11 @@ export type TStoreBusinessHours = {
 // api response
 export type TClassificationAllRes = { classifications: TClassification[] };
 
-// api response (대분류 태그 별 협업 지점 목록)
-export type TClassificationAllStore = { stores: TClassificationStore[] };
-
 // api request
 export type TClassificationParams = Omit<TClassification, "id" | "type">;
+
+// api response (대분류 태그 별 협업 지점 목록)
+export type TClassificationAllStore = { stores: TClassificationStore[] };
 
 // 지역 태그 (소분류)
 export type TSubClassification = {


### PR DESCRIPTION
### PR Type

- [x] 기능 개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update) (formatting, local variables)
- [x] 화면 작업 (Style, CSS)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 버그수정 (Bugfix)
- [ ] 빌드, 배포 관련 변경 (Build, Deploy)
- [ ] 문서 작업 (Docs)
- [ ] 그 외 (ETC)

## 작업 내용

- 협업 지점 소개 페이지 전체 협업 지점 목록 조회
- 상단의 소분류 태그 선택시 해당 소분류의 협업지점이 화면 상단에 오도록 자동 스크롤

## Before

## After

- 전체 화면
<img width="1374" alt="스크린샷 2023-09-16 오후 3 50 43" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/8569c878-31d1-425e-9173-28a0d08abed4">

- 테스트 1 태그 클릭시 스크롤 된 화면
<img width="1489" alt="스크린샷 2023-09-16 오후 3 50 50" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/fe5e11aa-07f3-4479-aa5b-423d66268ccd">



## To Reviewers (참고 사항, 첨부 자료 등)

- 화면에서 Null 이미지는 백엔드에서 보내주는 것이 아닌 이미지가 오지 않은 경우 에러가 발생해 임의로 넣어놓은 사진입니다.
- 이미지는 not nullable이라고 하셨고 아직 테스트데이터라 적용안해놓으신 것 같습니다!
- 스토어 컴포넌트 클릭시 상세정보를 조회하고자 했는데 404에러가 떠서 백엔드 분들께 문의 드린 상태입니다.
- 해당 이슈 합의 후에 다시 협업 지점 상세조회 로직을 짜서 완성하도록 하겠습니다.
- 이미지 스와이퍼 및 카드의 경우 반응형 화면을 위해 크기를 props로 받을 수 있도록 리팩토링 했습니다
