### PR TITLE
feat: 유저 어드민 구분 리다이렉트, 어드민관련 메뉴 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import "primereact/resources/primereact.min.css"; //core css
 import "primeicons/primeicons.css";
 import PrivateRoutes from "./utils/PrivateRoutes";
 import { Suspense } from "react";
+import AdminRoutes from "@/utils/AdminRoutes";
+import TempPage from "@/components/pages/temp/TempPage";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -45,8 +47,10 @@ function App() {
           <div className="bg-cover bg-basic">
             <div className="max-w-[1440px] min-h-[100vh] px-40 mx-auto flex flex-col sm:px-0">
               <Routes>
-                {/* Not Found Page */}
-                {/* Route */}
+                {/* hack */}
+                <Route path="/" element={<TempPage />} />
+
+                {/* include Header */}
                 <Route element={<MainLayout />}>
                   <>
                     {LAYOUT_ROUTES.map((route) => {
@@ -57,21 +61,27 @@ function App() {
                     <Route path="/*" element={<NotFound />} />
                   </>
                 </Route>
+
+                {/* Admin */}
                 <Route element={<MainLayout />}>
-                  {ADMIN_ROUTES.map((route) => {
-                    return (
-                      <Route
-                        key={route.name}
-                        path={route.path}
-                        element={
-                          <AdminWrapper>
-                            <route.component />
-                          </AdminWrapper>
-                        }
-                      />
-                    );
-                  })}
+                  <Route element={<AdminRoutes />}>
+                    {ADMIN_ROUTES.map((route) => {
+                      return (
+                        <Route
+                          key={route.name}
+                          path={route.path}
+                          element={
+                            <AdminWrapper>
+                              <route.component />
+                            </AdminWrapper>
+                          }
+                        />
+                      );
+                    })}
+                  </Route>
                 </Route>
+
+                {/* require login */}
                 <Route element={<PrivateRoutes />}>
                   {NOT_LAYOUT_ROUTES.map((route) => {
                     return (

--- a/src/components/molecules/Header/HeaderContents.tsx
+++ b/src/components/molecules/Header/HeaderContents.tsx
@@ -6,32 +6,53 @@ import HeaderMyPage from "@/components/atoms/Header/HeaderMyPage";
 import MenuIcon from "@mui/icons-material/Menu";
 import { NavLink } from "react-router-dom";
 import MobileMenu from "../MobileMenu";
+import { ADMIN_ROUTES_URL } from "@/routes/adminRouter";
+import { TUserRes } from "@/types/admin/userTypes";
 
 export type HeaderContentsProps = {
   isLoading: boolean;
-  name: string | null;
+  userRes: TUserRes | null;
 };
 
 export const headerNavItems = [
   {
     name: "업브렐라 이야기",
     path: "/about",
+    isAdmin: false,
   },
   {
     name: "대여소 위치",
     path: "/rentalLocation",
+    isAdmin: false,
   },
   {
     name: "협업 지점 소개",
     path: "/rentalOffice",
+    isAdmin: false,
   },
   {
     name: "이용안내",
     path: "/information",
+    isAdmin: false,
+  },
+  {
+    name: "어드민",
+    path: ADMIN_ROUTES_URL.rent.path,
+    isAdmin: true,
+  },
+  {
+    name: "대여폼테스트(어드민)",
+    path: "/rent/form/1",
+    isAdmin: true,
+  },
+  {
+    name: "반납폼테스트(어드민)",
+    path: "/return/form?storeId=1",
+    isAdmin: true,
   },
 ] as const;
 
-const HeaderContents = ({ isLoading, name }: HeaderContentsProps) => {
+const HeaderContents = ({ isLoading, userRes }: HeaderContentsProps) => {
   const navigate = useNavigate();
   const [infoBubbleOpen, setInfoBubbleOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -51,28 +72,35 @@ const HeaderContents = ({ isLoading, name }: HeaderContentsProps) => {
           <img className="w-64 h-64 p-8" src={Logo} alt="Logo" />
         </Link>
         <div className="flex justify-between text-16 font-semibold leading-24 text-gray-700">
-          {headerNavItems.map(({ name, path }) => (
-            <NavLink
-              key={name}
-              to={path}
-              className={({ isActive }) => {
-                let defaultClassName = "transition-all mr-32 p-8";
-                if (isActive) {
-                  defaultClassName +=
-                    " text-primary-500 border-solid border-b-2 border-primary-500";
-                }
+          {headerNavItems.map(({ name, path, isAdmin }) => {
+            // admin menu hide
+            if (isAdmin) {
+              if (!userRes || (userRes && !userRes.adminStatus)) return;
+            }
 
-                return defaultClassName;
-              }}
-            >
-              {name}
-            </NavLink>
-          ))}
+            return (
+              <NavLink
+                key={name}
+                to={path}
+                className={({ isActive }) => {
+                  let defaultClassName = "transition-all mr-32 p-8";
+                  if (isActive) {
+                    defaultClassName +=
+                      " text-primary-500 border-solid border-b-2 border-primary-500";
+                  }
 
-          {name ? (
+                  return defaultClassName;
+                }}
+              >
+                {name}
+              </NavLink>
+            );
+          })}
+
+          {userRes ? (
             <div className="flex items-center cursor-pointer relative" onClick={handleMyPageOpen}>
               <PersonOutlineOutlinedIcon sx={{ fontSize: "20px" }} />
-              <div className="ml-4">{name}님</div>
+              <div className="ml-4">{userRes.name}님</div>
               {infoBubbleOpen && (
                 <div className="absolute top-11 right-0">
                   <HeaderMyPage />
@@ -105,7 +133,7 @@ const HeaderContents = ({ isLoading, name }: HeaderContentsProps) => {
       {menuOpen && (
         <div className="fixed top-0 left-0 right-0 bottom-0 flex justify-center bg-white p-20 xl:hidden">
           <div className="xl:hidden lg:w-full lg:max-w-640 sm:w-full sm:max-w-360">
-            <MobileMenu name={name} setMenuOpen={setMenuOpen} />
+            <MobileMenu userRes={userRes} setMenuOpen={setMenuOpen} />
           </div>
         </div>
       )}

--- a/src/components/molecules/MobileMenu/index.stories.tsx
+++ b/src/components/molecules/MobileMenu/index.stories.tsx
@@ -6,7 +6,15 @@ export default {
   title: "Molecules/MobileMenu",
   component: MobileMenu,
   args: {
-    isLogin: true,
+    userRes: {
+      id: 10000,
+      name: "테스터",
+      phoneNumber: "010-1111-2222",
+      bank: null,
+      accountNumber: null,
+      email: "tester@gmail.com",
+      adminStatus: true,
+    },
     setMenuOpen: () => {
       // console.log("Menu is open:");
     },
@@ -20,8 +28,8 @@ export default {
   ],
 } as Meta;
 
-const Template: StoryFn<TMenu> = ({ name, setMenuOpen }) => (
-  <MobileMenu name={name} setMenuOpen={setMenuOpen} />
+const Template: StoryFn<TMenu> = ({ userRes, setMenuOpen }) => (
+  <MobileMenu userRes={userRes} setMenuOpen={setMenuOpen} />
 );
 
 export const Default = Template.bind({});

--- a/src/components/molecules/MobileMenu/index.tsx
+++ b/src/components/molecules/MobileMenu/index.tsx
@@ -6,13 +6,15 @@ import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { headerNavItems } from "@/components/molecules/Header/HeaderContents";
 import { useLogout } from "@/hooks/queries/userQueries";
+import { TUserRes } from "@/types/admin/userTypes";
+import { Fragment } from "react";
 
 export type TMenu = {
-  name: string | null;
+  userRes: TUserRes | null;
   setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const MobileMenu: React.FC<TMenu> = ({ name, setMenuOpen }) => {
+const MobileMenu: React.FC<TMenu> = ({ userRes, setMenuOpen }) => {
   const navigate = useNavigate();
   const { mutate } = useLogout();
 
@@ -43,11 +45,11 @@ const MobileMenu: React.FC<TMenu> = ({ name, setMenuOpen }) => {
         </div>
 
         <div className="flex flex-col py-20">
-          {name ? (
+          {userRes ? (
             <div className="flex justify-between mb-4">
               <div className="flex items-center mr-12 font-semibold text-20">
                 <PersonOutlineIcon />
-                <span className="ml-8">{name}</span>
+                <span className="ml-8">{userRes.name}</span>
               </div>
               <button
                 className="flex items-center justify-center text-primary-500  transition-all bg-primary-200 rounded-99 pl-16 pr-6 py-8 text-14 font-semibold"
@@ -69,23 +71,30 @@ const MobileMenu: React.FC<TMenu> = ({ name, setMenuOpen }) => {
               </button>
             </div>
           )}
-          {headerNavItems.map(({ name, path }) => (
-            <>
-              <div className="bg-gray-200 w-full h-1 my-16"></div>
-              <div>
-                <NavLink
-                  onClick={() => handleMenuClose()}
-                  key={name}
-                  to={path}
-                  className="px-16 text-15 text-gray-700 hover:text-primary-500  transition-all font-semibold"
-                >
-                  {name}
-                </NavLink>
-              </div>
-            </>
-          ))}
+          {headerNavItems.map(({ name, path, isAdmin }) => {
+            // admin menu hide
+            if (isAdmin) {
+              if (!userRes || (userRes && !userRes.adminStatus)) return;
+            }
+
+            return (
+              <Fragment key={name}>
+                <div className="bg-gray-200 w-full h-1 my-16"></div>
+                <div>
+                  <NavLink
+                    onClick={() => handleMenuClose()}
+                    key={name}
+                    to={path}
+                    className="px-16 text-15 text-gray-700 hover:text-primary-500  transition-all font-semibold"
+                  >
+                    {name}
+                  </NavLink>
+                </div>
+              </Fragment>
+            );
+          })}
           <div className="bg-gray-200 w-full h-1 my-16"></div>
-          {name && (
+          {userRes && (
             <button
               className="flex mx-16 text-14 font-semibold hover:text-primary-500  transition-all"
               onClick={onClickLogout}

--- a/src/components/organisms/Header/HeaderContainer.tsx
+++ b/src/components/organisms/Header/HeaderContainer.tsx
@@ -2,11 +2,11 @@ import HeaderContents from "@/components/molecules/Header/HeaderContents";
 import { useGetUserStatus } from "@/hooks/queries/userQueries";
 
 export const HeaderContainer = () => {
-  const { data, isLoading } = useGetUserStatus();
+  const { data: userRes, isLoading } = useGetUserStatus();
 
   return (
     <div className="h-80">
-      <HeaderContents isLoading={isLoading} name={data ? data.data.data.name : null} />
+      <HeaderContents isLoading={isLoading} userRes={userRes ? userRes.data.data : null} />
     </div>
   );
 };

--- a/src/components/pages/forbidden/ForbiddenPage.tsx
+++ b/src/components/pages/forbidden/ForbiddenPage.tsx
@@ -1,0 +1,12 @@
+import ErrorComponent from "@/components/molecules/ErrorComponent";
+
+const ForbiddenPage = () => {
+  return (
+    <ErrorComponent
+      error="죄송합니다. 페이지를 찾을 수 없어요:("
+      subError="접근 권한이 없습니다."
+    />
+  );
+};
+
+export default ForbiddenPage;

--- a/src/components/pages/return/index.tsx
+++ b/src/components/pages/return/index.tsx
@@ -148,114 +148,120 @@ const ReturnPage = () => {
   };
 
   return (
-    <div className="flex-col max-w-2xl mx-auto">
+    <>
       <HeaderContainer />
-      <div className="mt-20 text-24 font-semibold leading-32 text-black mb-32">
-        {!isReturn ? "우산을 반납할까요?" : "우산을 반납했어요!"}
-      </div>
-      <div className="mt-16 mb-32 max-w-2xl border border-gray-200 rounded-12 p-16">
-        <ul className="list-disc text-8 ml-16">
-          <li className="text-14 leading-20 gray-700">
-            수집된 개인정보는 <span className="inline font-semibold">서비스 운영의 목적으로만</span>{" "}
-            사용됩니다.
-          </li>
-          <li className="text-14 leading-20 gray-700">
-            대여 신청 시 정보를{" "}
-            <span className="inline text-red">
-              정확히 입력해주셔야{" "}
-              <span className="inline text-14 font-semibold">원활한 보증금 환급</span>
-            </span>
-            이 가능합니다.
-          </li>
-        </ul>
-      </div>
+      <div className="flex-col max-w-2xl mx-auto">
+        <div className="mt-20 text-24 font-semibold leading-32 text-black mb-32">
+          {!isReturn ? "우산을 반납할까요?" : "우산을 반납했어요!"}
+        </div>
+        <div className="mt-16 mb-32 max-w-2xl border border-gray-200 rounded-12 p-16">
+          <ul className="list-disc text-8 ml-16">
+            <li className="text-14 leading-20 gray-700">
+              수집된 개인정보는{" "}
+              <span className="inline font-semibold">서비스 운영의 목적으로만</span> 사용됩니다.
+            </li>
+            <li className="text-14 leading-20 gray-700">
+              대여 신청 시 정보를{" "}
+              <span className="inline text-red">
+                정확히 입력해주셔야{" "}
+                <span className="inline text-14 font-semibold">원활한 보증금 환급</span>
+              </span>
+              이 가능합니다.
+            </li>
+          </ul>
+        </div>
 
-      <FormBasic label="이름" value={name} />
-      <FormBasic label="전화번호" value={phone} />
-      <FormLocationMolecules region={classificationName} storeName={rentStoreName} />
-      <FormBasic label="우산번호" value={umbrellaUuid} />
+        <FormBasic label="이름" value={name} />
+        <FormBasic label="전화번호" value={phone} />
+        <FormLocationMolecules region={classificationName} storeName={rentStoreName} />
+        <FormBasic label="우산번호" value={umbrellaUuid} />
 
-      <div className="flex flex-col mb-32">
-        <div className="text-15 leading-22 text-gray-700 mb-8">환급받을 계좌</div>
-        <div className="flex justify-between w-full">
-          {isReturn ? (
-            <div className="relative w-120 flex items-center rounded-8 p-12 text-15 text-gray-500 leading-22 bg-gray-100">
-              <div className="w-120 text-15 leading-22 cursor-pointer focus:outline-none">
-                {bank}
+        <div className="flex flex-col mb-32">
+          <div className="text-15 leading-22 text-gray-700 mb-8">환급받을 계좌</div>
+          <div className="flex justify-between w-full">
+            {isReturn ? (
+              <div className="relative w-120 flex items-center rounded-8 p-12 text-15 text-gray-500 leading-22 bg-gray-100">
+                <div className="w-120 text-15 leading-22 cursor-pointer focus:outline-none">
+                  {bank}
+                </div>
+                <ExpandMoreIcon
+                  style={{ position: "absolute", right: "3", fontSize: "20px", color: "#999999" }}
+                />
               </div>
-              <ExpandMoreIcon
-                style={{ position: "absolute", right: "3", fontSize: "20px", color: "#999999" }}
-              />
-            </div>
-          ) : (
-            <div
-              className={`relative w-120 flex items-center rounded-8 p-12 border border-gray-300 bg-white ${
-                bank !== "은행명" ? "text-gray-700" : "text-gray-500"
-              }`}
-              onClick={() => setIsBottomSheetOpen(true)}
-            >
-              <div className="w-120 text-15 leading-22 cursor-pointer focus:outline-none">
-                {bank}
-              </div>
-              <ExpandMoreIcon
-                style={{ position: "absolute", right: "3", fontSize: "20px", color: "#1C1B1F" }}
-              />
-              <BottomSheet
-                isBottomSheetOpen={isBottomSheetOpen}
-                setIsBottomSheetOpen={setIsBottomSheetOpen}
-                snapPoints={[484, 272, 0]}
+            ) : (
+              <div
+                className={`relative w-120 flex items-center rounded-8 p-12 border border-gray-300 bg-white ${
+                  bank !== "은행명" ? "text-gray-700" : "text-gray-500"
+                }`}
+                onClick={() => setIsBottomSheetOpen(true)}
               >
-                <BankContent setBank={setBank} setIsBottomSheetOpen={setIsBottomSheetOpen} />
-              </BottomSheet>
-            </div>
-          )}
-          {isReturn ? (
-            <div className="w-full ml-4 rounded-8 p-12 text-15 text-gray-500 leading-22 bg-gray-100">
-              {accountNumber}
-            </div>
-          ) : (
-            <input
-              className={`ml-4 w-full rounded-8 p-12 focus:border-gray-600 focus:outline-none border border-gray-300`}
-              placeholder={accountNumber ? accountNumber : "계좌번호"}
-              value={accountNumber}
-              onChange={(e) => setAccountNumber(e.target.value)}
-            />
-          )}
+                <div className="w-120 text-15 leading-22 cursor-pointer focus:outline-none">
+                  {bank}
+                </div>
+                <ExpandMoreIcon
+                  style={{ position: "absolute", right: "3", fontSize: "20px", color: "#1C1B1F" }}
+                />
+                <BottomSheet
+                  isBottomSheetOpen={isBottomSheetOpen}
+                  setIsBottomSheetOpen={setIsBottomSheetOpen}
+                  snapPoints={[484, 272, 0]}
+                >
+                  <BankContent setBank={setBank} setIsBottomSheetOpen={setIsBottomSheetOpen} />
+                </BottomSheet>
+              </div>
+            )}
+            {isReturn ? (
+              <div className="w-full ml-4 rounded-8 p-12 text-15 text-gray-500 leading-22 bg-gray-100">
+                {accountNumber}
+              </div>
+            ) : (
+              <input
+                className={`ml-4 w-full rounded-8 p-12 focus:border-gray-600 focus:outline-none border border-gray-300`}
+                placeholder={accountNumber ? accountNumber : "계좌번호"}
+                value={accountNumber}
+                onChange={(e) => setAccountNumber(e.target.value)}
+              />
+            )}
+          </div>
+          <div className="mt-4 text-14 leading-20 text-gray-600">
+            * ‘-’은 빼고 입력해주세요! <br /> * 현재 ‘반납 페이지’에서 입력하신 은행, 계좌번호
+            정보는 보증금 환급이 완료됨에 따라 파기됩니다. <br /> * MYPAGE를 통해 정보를 저장하면
+            빠른 반납이 가능합니다.
+          </div>
         </div>
-        <div className="mt-4 text-14 leading-20 text-gray-600">
-          * ‘-’은 빼고 입력해주세요! <br /> * 현재 ‘반납 페이지’에서 입력하신 은행, 계좌번호 정보는
-          보증금 환급이 완료됨에 따라 파기됩니다. <br /> * MYPAGE를 통해 정보를 저장하면 빠른 반납이
-          가능합니다.
-        </div>
-      </div>
 
-      <FormStatus
-        label="개선 요청 사항"
-        placeholder="개선이 필요하다고 느낀 점이 있다면 작성해주세요!"
-        setStatus={setImprovementReportContent}
-        status={improvementReportContent}
-        isComplete={isReturn}
-      />
+        <FormStatus
+          label="개선 요청 사항"
+          placeholder="개선이 필요하다고 느낀 점이 있다면 작성해주세요!"
+          setStatus={setImprovementReportContent}
+          status={improvementReportContent}
+          isComplete={isReturn}
+        />
 
-      {!isReturn && (
-        <FormButton label="반납하기" isActive={isActive} handleOpen={() => setIsOpenModal(true)} />
-      )}
-
-      {isOpenModal && (
-        <FormModal height="380">
-          <ReturnModal
-            classificationName={classificationName}
-            rentStoreName={rentStoreName}
-            umbrellaUuid={umbrellaUuid}
-            elapsedDay={elapsedDay}
-            bank={bank}
-            accountNumber={accountNumber}
-            setIsOpenModal={setIsOpenModal}
-            onClickPatchBtn={onClickPatchBtn}
+        {!isReturn && (
+          <FormButton
+            label="반납하기"
+            isActive={isActive}
+            handleOpen={() => setIsOpenModal(true)}
           />
-        </FormModal>
-      )}
-    </div>
+        )}
+
+        {isOpenModal && (
+          <FormModal height="380">
+            <ReturnModal
+              classificationName={classificationName}
+              rentStoreName={rentStoreName}
+              umbrellaUuid={umbrellaUuid}
+              elapsedDay={elapsedDay}
+              bank={bank}
+              accountNumber={accountNumber}
+              setIsOpenModal={setIsOpenModal}
+              onClickPatchBtn={onClickPatchBtn}
+            />
+          </FormModal>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/src/components/pages/temp/TempPage.tsx
+++ b/src/components/pages/temp/TempPage.tsx
@@ -1,0 +1,10 @@
+import ErrorComponent from "@/components/molecules/ErrorComponent";
+
+// 개발중인 페이지
+const TempPage = () => {
+  return (
+    <ErrorComponent error="아직 개발중인 페이지입니다:(" subError="새로운 모습으로 찾아올게요 !" />
+  );
+};
+
+export default TempPage;

--- a/src/hooks/queries/userQueries.ts
+++ b/src/hooks/queries/userQueries.ts
@@ -7,7 +7,8 @@ import {
 } from "@/api/userApi";
 import { $axios } from "@/lib/axios";
 import { loginState, redirectUrl } from "@/recoil";
-import { TCustomError } from "@/types/commonTypes";
+import { TUserRes } from "@/types/admin/userTypes";
+import { TApiResponse, TCustomError } from "@/types/commonTypes";
 import { toast } from "react-hot-toast";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate } from "react-router-dom";
@@ -87,7 +88,7 @@ export const useGetUserStatus = () => {
 
   return useQuery({
     queryKey: [...USER_QUERY_KEYS.userStatus()],
-    queryFn: async () => await $axios.get("/users/loggedIn"),
+    queryFn: async () => await $axios.get<TApiResponse<TUserRes>>("/users/loggedIn"),
     retry: 0,
     keepPreviousData: true,
     onError: () => {

--- a/src/routes/layoutRouter.ts
+++ b/src/routes/layoutRouter.ts
@@ -1,5 +1,5 @@
 import { TRoute } from "@/types/commonTypes";
-import HomeMainPage from "@/components/pages/home/HomeMainPage";
+// import HomeMainPage from "@/components/pages/home/HomeMainPage";
 import RentalLocationPage from "@/components/pages/RentalLocation/RentalLocationPage";
 import RentalOfficePage from "@/components/pages/rentalOffice/RentalOfficePage";
 import SignUpPage from "@/components/pages/SignUp";
@@ -13,12 +13,13 @@ import MypageAccountPage from "@/components/pages/Mypage/MypageAccountPage";
  * Header, footer의 layout이 필요한 페이지
  * 라우트할 페이지의 path, component
  */
+// TODO: route 개선
 export const LAYOUT_ROUTES: TRoute[] = [
-  {
-    name: "메인 페이지",
-    path: "/",
-    component: HomeMainPage,
-  },
+  // {
+  //   name: "메인 페이지",
+  //   path: "/",
+  //   component: HomeMainPage,
+  // },
   {
     name: "대여소 위치 페이지",
     path: "/rentalLocation",

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -1,11 +1,14 @@
+import ForbiddenPage from "@/components/pages/forbidden/ForbiddenPage";
 import RentPage from "@/components/pages/rent";
 import ReturnPage from "@/components/pages/return";
+import TempPage from "@/components/pages/temp/TempPage";
 import { TRoute } from "@/types/commonTypes";
 
 /**
  * Header, footer의 layout이 필요없는 페이지
  * 라우트할 페이지의 path, component
  */
+// TODO: route 개선
 export const NOT_LAYOUT_ROUTES: TRoute[] = [
   {
     name: "대여폼 페이지",
@@ -16,5 +19,15 @@ export const NOT_LAYOUT_ROUTES: TRoute[] = [
     name: "반납폼 페이지",
     path: "/return/form",
     component: ReturnPage,
+  },
+  {
+    name: "접근 금지 페이지",
+    path: "/forbidden",
+    component: ForbiddenPage,
+  },
+  {
+    name: "메인 페이지",
+    path: "/",
+    component: TempPage,
   },
 ];

--- a/src/types/admin/userTypes.ts
+++ b/src/types/admin/userTypes.ts
@@ -5,7 +5,7 @@ export type TUserRes = {
   bank: string | null;
   accountNumber: string | null;
   adminStatus: boolean;
-  email: string | null;
+  email: string;
 };
 
 export type TBlackUserRes = {

--- a/src/utils/AdminRoutes.tsx
+++ b/src/utils/AdminRoutes.tsx
@@ -1,0 +1,23 @@
+import { useLayoutEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
+import { useGetUserStatus } from "@/hooks/queries/userQueries";
+
+// adminStatus checking
+const AdminRoutes = () => {
+  const { data, isLoading, isError } = useGetUserStatus();
+  const navigate = useNavigate();
+
+  useLayoutEffect(() => {
+    if (isError || (data && !data.data.data.adminStatus))
+      return navigate("/forbidden", { replace: true });
+  }, [data, isError, navigate]);
+
+  // hack
+  if (isLoading) {
+    return <></>;
+  }
+
+  return <Outlet />;
+};
+
+export default AdminRoutes;


### PR DESCRIPTION
### PR Type
- [x] 기능 개발 (Feature)
- [x] 코드 스타일 변경 (Code style update) (formatting, local variables)
- [x] 화면 작업 (Style, CSS)
- [x] 리팩토링 (no functional changes, no api changes)

## 작업 내용
유저별 어드민인지 아닌지의 데이터가 추가되어 그에 맞는 기능을 더 개발했습니다.
- 유저 response Type 추가
- 기존 메인 페이지 변경
- 어드민, 대여폼, 반납폼 메뉴 > 어드민 유저만 보이게 설정
- 어드민 페이지 > 어드민 유저만 접속할 수 있게 수정 

## Before
- 메인에 메뉴 버튼 존재
- 어드민 페이지 접속 가능 (다만 API 응답 확인 불가)

## After
- 메인, 로그인 안한 유저 헤더 메뉴 (어드민, 대여반납 메뉴 X)
<img width="1029" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76439533/f4ae3920-0008-4a47-9527-42fa12209d88">
<img width="532" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76439533/56f4b2e6-1959-4429-a392-94367e22ec15">

- 어드민 유저가 보이는 메뉴
<img width="1014" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76439533/70ef7b24-e0ef-4262-9369-20f95b5a197f">
<img width="537" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76439533/fb6df54a-804d-4864-ade5-20bfad1d26fb">

- 어드민이 아닌 유저가 어드민 페이지 방문 불가 -> 어드민 계정 로그인 후 정상 방문
![화면 기록 2023-09-22 오후 9 30 59](https://github.com/UPbrella/UPbrella_front/assets/76439533/388125f1-ca77-42ac-b7c6-33270c11d8bb)





## To Reviewers (참고 사항, 첨부 자료 등)
