### PR TITLE
fix: 이용내역 오류 수정, 계좌등록 바텀시트 추가

### DIFF
--- a/src/components/atoms/Mypage/MypageRentSection/index.tsx
+++ b/src/components/atoms/Mypage/MypageRentSection/index.tsx
@@ -14,36 +14,51 @@ export type TRentInfo = {
 };
 
 const MypageRentSection = ({ rentInfo, isProfile, isRecent }: MypageRentSectionProps) => {
-  const { umbrellaUuid, rentedAt, rentedStore, returnedDue, returnAt, returned, refunded } =
-    rentInfo;
+  const { umbrellaUuid, rentedAt, rentedStore, returnAt, returned, refunded } = rentInfo;
   const rentInfoContent = [
     ["우산 번호", String(umbrellaUuid)],
     ["대여 일자", rentedAt],
     ["대여 지점", rentedStore],
-    ["반납 기한", returnedDue],
+    ["반납 기한", returnAt],
     ["반납 일자", returnAt],
     ["반납 여부", returned],
     ["환급 여부", refunded],
   ];
-
-  const color = isRecent ? `bg-primary-100 border-primary-300` : `bg-white border-gray-200`;
+  const color =
+    isRecent && !returned ? `bg-primary-100 border-primary-300` : `bg-white border-gray-200`;
   const padding = isProfile ? `p-20` : `xl:p-24 lg:p-20`;
 
   return (
     <div className={`flex ${padding} ${color} border text-gray-700 border-solid rounded-12 w-full`}>
       <div className="flex flex-col text-15">
         {rentInfoContent.map((info, index) => {
-          if (info[0] === "우산 번호") {
+          if (index === 0) {
             if (typeof info[1] === "string" && info[1].length === 1) {
               info[1] = "0" + info[1];
             }
             info[1] += "번";
           }
-          if (info[0] === "반납 여부") {
+          if (index === 5) {
             info[1] = info[1] ? "반납 완료" : "반납 전";
           }
-          if (info[0] === "환급 여부") {
-            info[1] = info[1] ? "환급 완료" : "환급 전"; //TODO: 4가지 상태 가능하다.
+          if (index === 6) {
+            //환급여부
+            if (!info[1]) {
+              //환급 전
+              if (returned) {
+                // 반납완료 & 환급전
+                info[1] = "환급 중";
+              } else {
+                // 반납 전 & 환급전
+                info[1] = "환급 전";
+              }
+            } else {
+              //환급 완료
+              if (returned) {
+                // 반납완료 & 환급완료
+                info[1] = "환급 완료";
+              }
+            }
           }
           if (index === rentInfoContent.length - 1) {
             return (

--- a/src/components/molecules/Footer/FooterLabel/index.tsx
+++ b/src/components/molecules/Footer/FooterLabel/index.tsx
@@ -4,8 +4,28 @@ const FooterLabel = () => {
   const navigate = useNavigate();
   return (
     <div className="flex gap-6 text-sm text-gray-700">
-      <button>이용약관</button>
-      <button>개인정보처리방침</button>
+      <button
+        onClick={() => {
+          navigate("/info/tos");
+          window.scrollTo({
+            top: 0,
+            behavior: "smooth",
+          });
+        }}
+      >
+        이용약관
+      </button>
+      <button
+        onClick={() => {
+          navigate("/info/pp");
+          window.scrollTo({
+            top: 0,
+            behavior: "smooth",
+          });
+        }}
+      >
+        개인정보처리방침
+      </button>
       <button className="font-semibold" onClick={() => navigate("/contact")}>
         CONTACT_US
       </button>

--- a/src/components/molecules/Mypage/MypageContactSection/index.tsx
+++ b/src/components/molecules/Mypage/MypageContactSection/index.tsx
@@ -1,0 +1,34 @@
+import { Link } from "react-router-dom";
+
+type MypageContactSectionProps = {
+  content1: string;
+  content2: string;
+  buttonContent: string;
+  url: string;
+};
+
+const MypageContactSection = ({
+  content1,
+  content2,
+  buttonContent,
+  url,
+}: MypageContactSectionProps) => {
+  return (
+    <section className="w-full h-200 p-24 border border-solid border-gray-200 rounded-12">
+      <div className="h-full flex flex-col justify-between">
+        <div>
+          {content1}
+          <br />
+          {content2}
+        </div>
+        <Link
+          className="px-20 w-fit h-48 flex justify-center items-center rounded-8 bg-primary-200"
+          to={url}
+        >
+          <p className="text-primary-500 text-16 font-semibold leading-24">{buttonContent}</p>
+        </Link>
+      </div>
+    </section>
+  );
+};
+export default MypageContactSection;

--- a/src/components/molecules/Mypage/MypageModal/index.tsx
+++ b/src/components/molecules/Mypage/MypageModal/index.tsx
@@ -6,7 +6,9 @@ export type MypageModalProps = {
 const MypageModal = ({ children, width }: MypageModalProps) => {
   return (
     <div className="fixed top-0 bottom-0 left-0 right-0 z-50 flex items-center justify-center bg-black bg-opacity-20">
-      <div className={`w-${width} bg-white rounded-20 mx-20 p-32 flex justify-center items-center`}>
+      <div
+        className={`w-${width} bg-white rounded-20 mx-20 xl:p-32 lg:p-20 flex justify-center items-center`}
+      >
         <div>{children}</div>
       </div>
     </div>

--- a/src/components/molecules/Mypage/MypageModal/index.tsx
+++ b/src/components/molecules/Mypage/MypageModal/index.tsx
@@ -6,7 +6,7 @@ export type MypageModalProps = {
 const MypageModal = ({ children, width }: MypageModalProps) => {
   return (
     <div className="fixed top-0 bottom-0 left-0 right-0 z-50 flex items-center justify-center bg-black bg-opacity-20">
-      <div className={`w-${width} bg-white rounded-20 p-32 flex justify-center items-center`}>
+      <div className={`w-${width} bg-white rounded-20 mx-20 p-32 flex justify-center items-center`}>
         <div>{children}</div>
       </div>
     </div>

--- a/src/components/molecules/Mypage/MypageModal/index.tsx
+++ b/src/components/molecules/Mypage/MypageModal/index.tsx
@@ -1,11 +1,12 @@
 export type MypageModalProps = {
   children: JSX.Element;
+  width: string;
 };
 
-const MypageModal = ({ children }: MypageModalProps) => {
+const MypageModal = ({ children, width }: MypageModalProps) => {
   return (
     <div className="fixed top-0 bottom-0 left-0 right-0 z-50 flex items-center justify-center bg-black bg-opacity-20">
-      <div className="w-320 bg-white rounded-20 p-32 flex justify-center items-center">
+      <div className={`w-${width} bg-white rounded-20 p-32 flex justify-center items-center`}>
         <div>{children}</div>
       </div>
     </div>

--- a/src/components/molecules/Mypage/MypageModal/index.tsx
+++ b/src/components/molecules/Mypage/MypageModal/index.tsx
@@ -5,7 +5,7 @@ export type MypageModalProps = {
 const MypageModal = ({ children }: MypageModalProps) => {
   return (
     <div className="fixed top-0 bottom-0 left-0 right-0 z-50 flex items-center justify-center bg-black bg-opacity-20">
-      <div className={`w-320 bg-white rounded-20 p-32 flex justify-center items-center`}>
+      <div className="w-320 bg-white rounded-20 p-32 flex justify-center items-center">
         <div>{children}</div>
       </div>
     </div>

--- a/src/components/molecules/Mypage/MypageModal/index.tsx
+++ b/src/components/molecules/Mypage/MypageModal/index.tsx
@@ -1,0 +1,15 @@
+export type MypageModalProps = {
+  children: JSX.Element;
+};
+
+const MypageModal = ({ children }: MypageModalProps) => {
+  return (
+    <div className="fixed top-0 bottom-0 left-0 right-0 z-50 flex items-center justify-center bg-black bg-opacity-20">
+      <div className={`w-320 bg-white rounded-20 p-32 flex justify-center items-center`}>
+        <div>{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default MypageModal;

--- a/src/components/molecules/Mypage/MypageModalChildren/index.tsx
+++ b/src/components/molecules/Mypage/MypageModalChildren/index.tsx
@@ -1,11 +1,15 @@
 export type MypageModalChildrenProps = {
   label: string;
+  onClickBtn: () => void;
 };
-const MypageModalChildren = ({ label }: MypageModalChildrenProps) => {
+const MypageModalChildren = ({ label, onClickBtn }: MypageModalChildrenProps) => {
   return (
     <div className="flex flex-col justify-center items-center">
       <div className="text-gray-700 text-24 font-semibold leading-32 mb-24">{label}</div>
-      <button className="w-160 h-56 px-32 flex justify-center items-center bg-primary-500 rounded-8">
+      <button
+        className="w-160 h-56 px-32 flex justify-center items-center bg-primary-500 rounded-8"
+        onClick={onClickBtn}
+      >
         <p className="text-white text-18 font-semibold leading-24">확인</p>
       </button>
     </div>

--- a/src/components/molecules/Mypage/MypageModalChildren/index.tsx
+++ b/src/components/molecules/Mypage/MypageModalChildren/index.tsx
@@ -1,0 +1,14 @@
+export type MypageModalChildrenProps = {
+  label: string;
+};
+const MypageModalChildren = ({ label }: MypageModalChildrenProps) => {
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <div className="text-gray-700 text-24 font-semibold leading-32 mb-24">{label}</div>
+      <button className="w-160 h-56 px-32 flex justify-center items-center bg-primary-500 rounded-8">
+        <p className="text-white text-18 font-semibold leading-24">확인</p>
+      </button>
+    </div>
+  );
+};
+export default MypageModalChildren;

--- a/src/components/molecules/Mypage/MypageModalNotAllowedChildren/index.tsx
+++ b/src/components/molecules/Mypage/MypageModalNotAllowedChildren/index.tsx
@@ -1,0 +1,28 @@
+export type MypageModalNotAllowedChildrenProps = {
+  label: string;
+  notAllowedMessage: string;
+  onClickBtn: () => void;
+};
+const MypageModalNotAllowedChildren = ({
+  label,
+  notAllowedMessage,
+  onClickBtn,
+}: MypageModalNotAllowedChildrenProps) => {
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <div className="w-full">
+        <div className="text-gray-700 text-18 font-semibold leading-24">{label}</div>
+      </div>
+      <div className="mt-16 xl:mb-24 lg:mb-16 text-15 font-normal leading-22 font-gray-700">
+        {notAllowedMessage}
+      </div>
+      <button
+        className="w-160 h-56 px-32 flex justify-center items-center bg-primary-500 rounded-8"
+        onClick={onClickBtn}
+      >
+        <p className="text-white text-18 font-semibold leading-24">확인</p>
+      </button>
+    </div>
+  );
+};
+export default MypageModalNotAllowedChildren;

--- a/src/components/molecules/Mypage/MypageModalTwoBtnChildren/index.tsx
+++ b/src/components/molecules/Mypage/MypageModalTwoBtnChildren/index.tsx
@@ -1,5 +1,6 @@
 export type MypageModalTwoBtnChildrenProps = {
   label: string;
+  content?: string[];
   btnLabel: string;
   onClickCancel: () => void;
   onClickOkay: () => void;
@@ -7,12 +8,31 @@ export type MypageModalTwoBtnChildrenProps = {
 const MypageModalTwoBtnChildren = ({
   label,
   btnLabel,
+  content,
   onClickCancel,
   onClickOkay,
 }: MypageModalTwoBtnChildrenProps) => {
   return (
-    <div className="flex flex-col justify-center items-center">
-      <div className="text-gray-700 text-24 font-semibold leading-32 mb-24">{label}</div>
+    <div className="flex flex-col justify-center">
+      <div className="text-gray-700 text-24 font-semibold leading-32 mb-16">{label}</div>
+      {content ? (
+        <div className="mb-24">
+          <div className="mb-8">
+            <div>{content[0]}</div>
+            <div>{content[1]}</div>
+          </div>
+          <div>
+            <div className="flex">
+              <p className="mx-8">•</p>
+              {content[2]}
+            </div>
+            <div className="flex">
+              <p className="mx-8">•</p>
+              {content[3]}
+            </div>
+          </div>
+        </div>
+      ) : null}
       <div className="flex w-full">
         <button
           className="w-full h-56 px-32 flex justify-center items-center bg-white rounded-8 border border-gray-300 mr-8"

--- a/src/components/molecules/Mypage/MypageModalTwoBtnChildren/index.tsx
+++ b/src/components/molecules/Mypage/MypageModalTwoBtnChildren/index.tsx
@@ -14,9 +14,11 @@ const MypageModalTwoBtnChildren = ({
 }: MypageModalTwoBtnChildrenProps) => {
   return (
     <div className="flex flex-col justify-center">
-      <div className="text-gray-700 text-24 font-semibold leading-32 mb-16">{label}</div>
+      <div className="text-gray-700 text-24 font-semibold leading-32 xl:mb-24 lg:mb-16">
+        {label}
+      </div>
       {content ? (
-        <div className="mb-24">
+        <div className="xl:mb-24 lg:mb-16">
           <div className="mb-8">
             <div>{content[0]}</div>
             <div>{content[1]}</div>

--- a/src/components/molecules/Mypage/MypageModalTwoBtnChildren/index.tsx
+++ b/src/components/molecules/Mypage/MypageModalTwoBtnChildren/index.tsx
@@ -1,0 +1,33 @@
+export type MypageModalTwoBtnChildrenProps = {
+  label: string;
+  btnLabel: string;
+  onClickCancel: () => void;
+  onClickOkay: () => void;
+};
+const MypageModalTwoBtnChildren = ({
+  label,
+  btnLabel,
+  onClickCancel,
+  onClickOkay,
+}: MypageModalTwoBtnChildrenProps) => {
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <div className="text-gray-700 text-24 font-semibold leading-32 mb-24">{label}</div>
+      <div className="flex w-full">
+        <button
+          className="w-full h-56 px-32 flex justify-center items-center bg-white rounded-8 border border-gray-300 mr-8"
+          onClick={onClickCancel}
+        >
+          <p className="text-gray-700 text-18 font-semibold leading-24">취소</p>
+        </button>
+        <button
+          className="w-full h-56 px-32 flex justify-center items-center bg-primary-500 rounded-8"
+          onClick={onClickOkay}
+        >
+          <p className="text-white text-18 font-semibold leading-24">{btnLabel}</p>
+        </button>
+      </div>
+    </div>
+  );
+};
+export default MypageModalTwoBtnChildren;

--- a/src/components/organisms/Mypage/MypageAccountCard/index.tsx
+++ b/src/components/organisms/Mypage/MypageAccountCard/index.tsx
@@ -1,3 +1,5 @@
+import BottomSheet from "@/components/atoms/BottomSheet";
+import BankContent from "@/components/atoms/Form/BankContent";
 import MypageBankAccountInput from "@/components/molecules/Mypage/MypageBankAccountInput";
 import BankModal from "@/components/organisms/BankModal";
 import { BankIcon } from "@/constants/BankIcon";
@@ -10,6 +12,9 @@ export type MypageAccountCardProps = {
   onClickBankArrow: () => void;
   bankRef: React.RefObject<HTMLInputElement>;
   isOpenModal: boolean;
+  isBottomSheetOpen: boolean;
+  setIsBottomSheetOpen: (value: boolean) => void;
+  setBank: (value: string) => void;
   handleClose: () => void;
   handleClickBank: (event: MouseEvent<HTMLDivElement>) => void;
   hasBankAccountInfo: boolean;
@@ -25,6 +30,9 @@ const MypageAccountCard = ({
   onClickBankArrow,
   bankRef,
   isOpenModal,
+  isBottomSheetOpen,
+  setIsBottomSheetOpen,
+  setBank,
   handleClose,
   handleClickBank,
   hasBankAccountInfo,
@@ -46,26 +54,37 @@ const MypageAccountCard = ({
         onClick={onClickBankArrow}
         bankRef={bankRef}
       />
-      <BankModal
-        titleText="은행을 선택해주세요"
-        isOpen={isOpenModal}
-        handleClose={handleClose}
-        children={
-          <div className="grid grid-cols-3 gap-4">
-            {banks.map(([bankName, icon]) => (
-              <div key={bankName}>
-                <div
-                  className="w-full mb-8 p-12 flex flex-col items-center justify-center  cursor-pointer"
-                  onClick={handleClickBank}
-                >
-                  <div className="w-24 h-24">{icon}</div>
-                  <div className={`mt-4 text-15 leading-22 text-gray-700`}>{bankName}</div>
+      {window.innerWidth > 1025 ? (
+        <BankModal
+          titleText="은행을 선택해주세요"
+          isOpen={isOpenModal}
+          handleClose={handleClose}
+          children={
+            <div className="grid grid-cols-3 gap-4">
+              {banks.map(([bankName, icon]) => (
+                <div key={bankName}>
+                  <div
+                    className="w-full mb-8 p-12 flex flex-col items-center justify-center  cursor-pointer"
+                    onClick={handleClickBank}
+                  >
+                    <div className="w-24 h-24">{icon}</div>
+                    <div className={`mt-4 text-15 leading-22 text-gray-700`}>{bankName}</div>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        }
-      />
+              ))}
+            </div>
+          }
+        />
+      ) : (
+        <BottomSheet
+          isBottomSheetOpen={isBottomSheetOpen}
+          setIsBottomSheetOpen={setIsBottomSheetOpen}
+          snapPoints={[484, 272, 0]}
+        >
+          <BankContent setBank={setBank} setIsBottomSheetOpen={setIsBottomSheetOpen} />
+        </BottomSheet>
+      )}
+
       <div className="flex justify-end mt-8">
         {hasBankAccountInfo ? (
           <button

--- a/src/components/organisms/Mypage/MypageContactCard/index.tsx
+++ b/src/components/organisms/Mypage/MypageContactCard/index.tsx
@@ -1,0 +1,29 @@
+import MypageContactSection from "@/components/molecules/Mypage/MypageContactSection";
+
+const MypageContactCard = () => {
+  return (
+    <div className="xl:py-24 lg:pt-8 w-full">
+      <div className="text-black text-32 font-semibold leading-40 mb-24 lg:hidden">문의하기</div>
+      <div className="xl:flex xl:justify-between">
+        <div className="w-full xl:mr-8 lg:mb-16">
+          <MypageContactSection
+            content1={`업브렐라 이용 관련 및 급한 문의는`}
+            content2={"업브렐라 인스타그램 계정으로 부탁드려요!"}
+            buttonContent="업브렐라 DM으로 문의하기"
+            url={"https://www.instagram.com/upbrella.sinchon/"}
+          />
+        </div>
+        <div className="w-full xl:ml-8">
+          <MypageContactSection
+            content1={`업브렐라와의 사업 제휴 관련 문의는`}
+            content2={"Contact Us에서 부탁드려요!"}
+            buttonContent="CONTACT US에서 문의하기"
+            url={"/contact"}
+          />
+        </div>
+      </div>
+      <div className="flex justify-end mt-8"></div>
+    </div>
+  );
+};
+export default MypageContactCard;

--- a/src/components/pages/Mypage/MypageAccountPage/index.tsx
+++ b/src/components/pages/Mypage/MypageAccountPage/index.tsx
@@ -26,6 +26,7 @@ const MypageAccountPage = () => {
     accountNumber: "",
   });
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const [hasBankAccountInfo, setHasBankAccountInfo] = useState<boolean>(false);
   const [status, setStatus] = useState<TStatus>({
     isDeleted: false,
@@ -78,6 +79,7 @@ const MypageAccountPage = () => {
 
   const onClickBankArrow = () => {
     setIsOpenModal(!isOpenModal);
+    setIsBottomSheetOpen(!isBottomSheetOpen);
   };
 
   const handleClose = () => {
@@ -90,6 +92,9 @@ const MypageAccountPage = () => {
       setInputs({ ...inputs, [bankInput.current.name]: bankName });
       setIsOpenModal(!isOpenModal);
     }
+  };
+  const setBank = (value: string) => {
+    setInputs({ ...inputs, bank: value });
   };
 
   const handleDeleteAccount = async () => {
@@ -135,6 +140,9 @@ const MypageAccountPage = () => {
               onClickBankArrow={onClickBankArrow}
               bankRef={bankInput}
               isOpenModal={isOpenModal}
+              isBottomSheetOpen={isBottomSheetOpen}
+              setIsBottomSheetOpen={setIsBottomSheetOpen}
+              setBank={setBank}
               handleClose={handleClose}
               handleClickBank={handleClickBank}
               hasBankAccountInfo={hasBankAccountInfo}

--- a/src/components/pages/Mypage/MypageAccountPage/index.tsx
+++ b/src/components/pages/Mypage/MypageAccountPage/index.tsx
@@ -147,7 +147,7 @@ const MypageAccountPage = () => {
             />
           </div>
           {status.isDeleted ? (
-            <MypageModal>
+            <MypageModal width="320">
               <MypageModalTwoBtnChildren
                 label="계좌를 삭제하시겠어요?"
                 btnLabel="삭제"
@@ -159,7 +159,7 @@ const MypageAccountPage = () => {
             </MypageModal>
           ) : null}
           {status.isChanged ? (
-            <MypageModal>
+            <MypageModal width="320">
               <MypageModalChildren
                 label="계좌 변경 완료!"
                 onClickBtn={() => {
@@ -169,7 +169,7 @@ const MypageAccountPage = () => {
             </MypageModal>
           ) : null}
           {status.isRegistered ? (
-            <MypageModal>
+            <MypageModal width="320">
               <MypageModalChildren
                 label="계좌 등록 완료!"
                 onClickBtn={() => {

--- a/src/components/pages/Mypage/MypageAccountPage/index.tsx
+++ b/src/components/pages/Mypage/MypageAccountPage/index.tsx
@@ -1,9 +1,11 @@
 import MypageAccountCard from "@/components/organisms/Mypage/MypageAccountCard";
 import MypageLeftCard from "@/components/organisms/Mypage/MypageLeftCard";
 import { $axios } from "@/lib/axios";
-import { loginInfo } from "@/recoil";
+import { loginInfo, loginState } from "@/recoil";
 import { ChangeEvent, MouseEvent, useEffect, useRef, useState } from "react";
-import { useRecoilValueLoadable } from "recoil";
+import { toast } from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+import { useRecoilState, useRecoilValueLoadable } from "recoil";
 
 export type TAccountPageInputs = {
   bank: string;
@@ -18,8 +20,11 @@ const MypageAccountPage = () => {
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
   const [hasBankAccountInfo, setHasBankAccountInfo] = useState<boolean>(false);
 
+  const [isLogin] = useRecoilState<boolean>(loginState);
   const loginInfoValue = useRecoilValueLoadable(loginInfo);
   const bankInput = useRef<HTMLInputElement>(null);
+
+  const navigate = useNavigate();
 
   const { bank, accountNumber } = inputs;
 
@@ -47,7 +52,12 @@ const MypageAccountPage = () => {
     };
 
     getBankAccountInfo();
-  }, [loginInfoValue.state, loginInfoValue.contents]);
+    if (!isLogin) {
+      toast.error(`로그인 세션이 만료되었습니다. 
+      다시 로그인해주세요.`);
+      navigate("/");
+    }
+  }, [loginInfoValue.state, loginInfoValue.contents, isLogin, navigate]);
   const handleInputValue = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setInputs({ ...inputs, [name]: value });

--- a/src/components/pages/Mypage/MypageAccountPage/index.tsx
+++ b/src/components/pages/Mypage/MypageAccountPage/index.tsx
@@ -1,3 +1,6 @@
+import MypageModal from "@/components/molecules/Mypage/MypageModal";
+import MypageModalChildren from "@/components/molecules/Mypage/MypageModalChildren";
+import MypageModalTwoBtnChildren from "@/components/molecules/Mypage/MypageModalTwoBtnChildren";
 import MypageAccountCard from "@/components/organisms/Mypage/MypageAccountCard";
 import MypageLeftCard from "@/components/organisms/Mypage/MypageLeftCard";
 import { $axios } from "@/lib/axios";
@@ -11,6 +14,11 @@ export type TAccountPageInputs = {
   bank: string;
   accountNumber: string;
 };
+export type TStatus = {
+  isDeleted: boolean;
+  isChanged: boolean;
+  isRegistered: boolean;
+};
 
 const MypageAccountPage = () => {
   const [inputs, setInputs] = useState<TAccountPageInputs>({
@@ -19,6 +27,11 @@ const MypageAccountPage = () => {
   });
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
   const [hasBankAccountInfo, setHasBankAccountInfo] = useState<boolean>(false);
+  const [status, setStatus] = useState<TStatus>({
+    isDeleted: false,
+    isChanged: false,
+    isRegistered: false,
+  });
 
   const [isLogin] = useRecoilState<boolean>(loginState);
   const loginInfoValue = useRecoilValueLoadable(loginInfo);
@@ -87,7 +100,7 @@ const MypageAccountPage = () => {
       };
       setInputs({ ...data });
       setHasBankAccountInfo(false);
-      alert("계좌 삭제 완료!");
+      setStatus({ ...status, isDeleted: false });
     });
   };
   //   계좌 등록과 수정 모두 같은 patch api 요청
@@ -95,14 +108,14 @@ const MypageAccountPage = () => {
     await $axios.patch("/users/bankAccount", { ...inputs }, { withCredentials: true }).then(() => {
       setInputs({ ...inputs });
       setHasBankAccountInfo(true);
-      alert("계좌 변경 완료!");
+      setStatus({ ...status, isChanged: true });
     });
   };
   const handleRegisterAccount = async () => {
     await $axios.patch("/users/bankAccount", { ...inputs }, { withCredentials: true }).then(() => {
       setInputs({ ...inputs });
       setHasBankAccountInfo(true);
-      alert("계좌 등록 완료!");
+      setStatus({ ...status, isRegistered: true });
     });
   };
 
@@ -126,11 +139,45 @@ const MypageAccountPage = () => {
               handleClickBank={handleClickBank}
               hasBankAccountInfo={hasBankAccountInfo}
               isInputCompleted={bank !== "" && accountNumber !== ""}
-              onClickDeleteButton={handleDeleteAccount}
+              onClickDeleteButton={() => {
+                setStatus({ ...status, isDeleted: true });
+              }}
               onClickChangeButton={handleChangeAccount}
               onClickRegisterButton={handleRegisterAccount}
             />
           </div>
+          {status.isDeleted ? (
+            <MypageModal>
+              <MypageModalTwoBtnChildren
+                label="계좌를 삭제하시겠어요?"
+                btnLabel="삭제"
+                onClickCancel={() => {
+                  setStatus({ ...status, isDeleted: false });
+                }}
+                onClickOkay={handleDeleteAccount}
+              />
+            </MypageModal>
+          ) : null}
+          {status.isChanged ? (
+            <MypageModal>
+              <MypageModalChildren
+                label="계좌 변경 완료!"
+                onClickBtn={() => {
+                  setStatus({ ...status, isChanged: false });
+                }}
+              />
+            </MypageModal>
+          ) : null}
+          {status.isRegistered ? (
+            <MypageModal>
+              <MypageModalChildren
+                label="계좌 등록 완료!"
+                onClickBtn={() => {
+                  setStatus({ ...status, isRegistered: false });
+                }}
+              />
+            </MypageModal>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/pages/Mypage/MypageContactPage/index.tsx
+++ b/src/components/pages/Mypage/MypageContactPage/index.tsx
@@ -1,0 +1,36 @@
+import MypageContactCard from "@/components/organisms/Mypage/MypageContactCard";
+import MypageLeftCard from "@/components/organisms/Mypage/MypageLeftCard";
+import { loginState } from "@/recoil";
+import { useEffect } from "react";
+import { toast } from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
+
+const MypageContactPage = () => {
+  const [isLogin] = useRecoilState<boolean>(loginState);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLogin) {
+      toast.error(`로그인 세션이 만료되었습니다. 
+      다시 로그인해주세요.`);
+      navigate("/");
+    }
+  }, [isLogin, navigate]);
+
+  return (
+    <div className="flex justify-center">
+      <div className="flex flex-col w-full xl:w-[1280px] xl:mt-24 xl:px-40 lg:max-w-640 lg:py-20 lg:w-full lg:px-20">
+        <div className="text-black text-24 font-semibold leading-32 mb-32">MYPAGE</div>
+        <div className="xl:flex">
+          <div className="xl:mr-32">
+            <MypageLeftCard />
+          </div>
+          <MypageContactCard />
+        </div>
+      </div>
+    </div>
+  );
+};
+export default MypageContactPage;

--- a/src/components/pages/Mypage/MypageInfoPage/index.tsx
+++ b/src/components/pages/Mypage/MypageInfoPage/index.tsx
@@ -1,3 +1,5 @@
+import MypageModal from "@/components/molecules/Mypage/MypageModal";
+import MypageModalTwoBtnChildren from "@/components/molecules/Mypage/MypageModalTwoBtnChildren";
 import MypageInfoCard from "@/components/organisms/Mypage/MypageInfoCard";
 import MypageLeftCard from "@/components/organisms/Mypage/MypageLeftCard";
 import { $axios } from "@/lib/axios";
@@ -20,6 +22,7 @@ const MypageInfoPage = () => {
     phoneNumber: "",
     email: "",
   });
+  const [isDeleted, setIsDeleted] = useState<boolean>(false);
   const [isLogin, setIsLogin] = useRecoilState<boolean>(loginState);
   const loginInfoValue = useRecoilValueLoadable(loginInfo);
 
@@ -54,7 +57,7 @@ const MypageInfoPage = () => {
   const handleDeleteUser = async () => {
     try {
       await $axios.get("/users/loggedIn/umbrella", { withCredentials: true });
-      alert("지금은 탈퇴가 불가능합니다. 대여중인 우산이 있습니다.");
+      toast.error("지금은 탈퇴가 불가능합니다. 대여중인 우산이 있습니다.");
     } catch {
       await axios
         .all([
@@ -62,13 +65,15 @@ const MypageInfoPage = () => {
           $axios.delete("/users/loggedIn", { withCredentials: true }),
         ])
         .then(() => {
+          setIsDeleted(false);
           setIsLogin(false);
           navigate("/");
           location.reload();
-          alert("회원탈퇴 완료했습니다!");
+          toast.success("회원탈퇴 완료했습니다!");
         })
         .catch(() => {
-          alert("오류가 발생했습니다. 다시 시도해주세요.");
+          setIsDeleted(false);
+          toast.error("오류가 발생했습니다. 다시 시도해주세요.");
         });
     }
   };
@@ -84,8 +89,28 @@ const MypageInfoPage = () => {
             name={infos.name}
             phoneNumber={infos.phoneNumber}
             email={infos.email}
-            onClickButton={handleDeleteUser}
+            onClickButton={() => {
+              setIsDeleted(true);
+            }}
           />
+          {isDeleted ? (
+            <MypageModal width="520">
+              <MypageModalTwoBtnChildren
+                label="정말 탈퇴하시겠어요?"
+                content={[
+                  "그동안 업브렐라를 이용해주셔서 감사합니다.",
+                  "회원탈퇴를 하실 경우, 아래와 같이 회원정보가 처리됩니다.",
+                  "탈퇴 신청 즉시 회원 탈퇴 처리되며, 회원 정보는 삭제 처리됩니다.",
+                  "대여 중인 우산이 남아있는 경우, 즉시 탈퇴가 불가하니 문의 바랍니다.",
+                ]}
+                btnLabel="탈퇴"
+                onClickCancel={() => {
+                  setIsDeleted(false);
+                }}
+                onClickOkay={handleDeleteUser}
+              />
+            </MypageModal>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/pages/Mypage/MypageInfoPage/index.tsx
+++ b/src/components/pages/Mypage/MypageInfoPage/index.tsx
@@ -4,8 +4,9 @@ import { $axios } from "@/lib/axios";
 import { loginInfo, loginState } from "@/recoil";
 import axios from "axios";
 import { useEffect, useState } from "react";
+import { toast } from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
-import { useSetRecoilState, useRecoilValueLoadable } from "recoil";
+import { useRecoilState, useRecoilValueLoadable } from "recoil";
 
 type TInfos = {
   name: string;
@@ -19,7 +20,7 @@ const MypageInfoPage = () => {
     phoneNumber: "",
     email: "",
   });
-  const setIsLogin = useSetRecoilState<boolean>(loginState);
+  const [isLogin, setIsLogin] = useRecoilState<boolean>(loginState);
   const loginInfoValue = useRecoilValueLoadable(loginInfo);
 
   const navigate = useNavigate();
@@ -44,7 +45,12 @@ const MypageInfoPage = () => {
       }
     };
     getInfos();
-  }, [loginInfoValue.contents, loginInfoValue.state]);
+    if (!isLogin) {
+      toast.error(`로그인 세션이 만료되었습니다. 
+      다시 로그인해주세요.`);
+      navigate("/");
+    }
+  }, [isLogin, loginInfoValue.contents, loginInfoValue.state, navigate]);
   const handleDeleteUser = async () => {
     try {
       await $axios.get("/users/loggedIn/umbrella", { withCredentials: true });

--- a/src/components/pages/Mypage/MypageInfoPage/index.tsx
+++ b/src/components/pages/Mypage/MypageInfoPage/index.tsx
@@ -1,4 +1,5 @@
 import MypageModal from "@/components/molecules/Mypage/MypageModal";
+import MypageModalNotAllowedChildren from "@/components/molecules/Mypage/MypageModalNotAllowedChildren";
 import MypageModalTwoBtnChildren from "@/components/molecules/Mypage/MypageModalTwoBtnChildren";
 import MypageInfoCard from "@/components/organisms/Mypage/MypageInfoCard";
 import MypageLeftCard from "@/components/organisms/Mypage/MypageLeftCard";
@@ -23,6 +24,7 @@ const MypageInfoPage = () => {
     email: "",
   });
   const [isDeleted, setIsDeleted] = useState<boolean>(false);
+  const [isDeleteAllowed, setIsDeleteAllowed] = useState<boolean>(true);
   const [isLogin, setIsLogin] = useRecoilState<boolean>(loginState);
   const loginInfoValue = useRecoilValueLoadable(loginInfo);
 
@@ -57,7 +59,8 @@ const MypageInfoPage = () => {
   const handleDeleteUser = async () => {
     try {
       await $axios.get("/users/loggedIn/umbrella", { withCredentials: true });
-      toast.error("지금은 탈퇴가 불가능합니다. 대여중인 우산이 있습니다.");
+      setIsDeleted(false);
+      setIsDeleteAllowed(false);
     } catch {
       await axios
         .all([
@@ -111,6 +114,17 @@ const MypageInfoPage = () => {
               />
             </MypageModal>
           ) : null}
+          {isDeleteAllowed ? null : (
+            <MypageModal width="320">
+              <MypageModalNotAllowedChildren
+                label="지금은 탈퇴가 불가합니다"
+                notAllowedMessage="현재 대여 중인 우산이 있어 탈퇴가 불가하오니, 인스타그램 DM 문의 바랍니다."
+                onClickBtn={() => {
+                  setIsDeleteAllowed(true);
+                }}
+              />
+            </MypageModal>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/pages/Mypage/MypageRentPage/index.tsx
+++ b/src/components/pages/Mypage/MypageRentPage/index.tsx
@@ -1,13 +1,15 @@
 import { TRentContentInfo } from "@/components/molecules/Mypage/MypageRentList";
 import MypageLeftCard from "@/components/organisms/Mypage/MypageLeftCard";
 import MypageRentCard from "@/components/organisms/Mypage/MypageRentCard";
-import { rentHistories } from "@/recoil";
+import { loginState, rentHistories } from "@/recoil";
 import { useEffect, useState } from "react";
+import { toast } from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
-import { useRecoilValueLoadable } from "recoil";
+import { useRecoilState, useRecoilValueLoadable } from "recoil";
 
 const MypageRentPage = () => {
   const [rentList, setRentList] = useState<TRentContentInfo[]>([]);
+  const [isLogin] = useRecoilState<boolean>(loginState);
   const umbrellaHistories = useRecoilValueLoadable(rentHistories);
 
   const navigate = useNavigate();
@@ -28,7 +30,12 @@ const MypageRentPage = () => {
       }
     };
     getRentList();
-  }, [umbrellaHistories, navigate]);
+    if (!isLogin) {
+      toast.error(`로그인 세션이 만료되었습니다. 
+      다시 로그인해주세요.`);
+      navigate("/");
+    }
+  }, [umbrellaHistories, navigate, isLogin]);
 
   return (
     <div className="flex justify-center">

--- a/src/routes/layoutRouter.ts
+++ b/src/routes/layoutRouter.ts
@@ -11,6 +11,7 @@ import ContactPage from "@/components/pages/contact/ContactPage";
 import MypageInfoPage from "@/components/pages/Mypage/MypageInfoPage";
 import TermsOfService from "@/components/pages/tos";
 import PrivacyPolicy from "@/components/pages/pp";
+import MypageContactPage from "@/components/pages/Mypage/MypageContactPage";
 
 /**
  * Header, footer의 layout이 필요한 페이지
@@ -62,6 +63,11 @@ export const LAYOUT_ROUTES: TRoute[] = [
     name: "마이페이지_개인정보조회",
     path: "/members/mypage/info",
     component: MypageInfoPage,
+  },
+  {
+    name: "마이페이지_문의하기",
+    path: "/members/mypage/contact",
+    component: MypageContactPage,
   },
   {
     name: "이용약관 페이지",


### PR DESCRIPTION
### PR Type

- [ ] 기능 개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update) (formatting, local variables)
- [ ] 화면 작업 (Style, CSS)
- [ ] 리팩토링 (no functional changes, no api changes)
- [X] 버그수정 (Bugfix)
- [ ] 빌드, 배포 관련 변경 (Build, Deploy)
- [ ] 문서 작업 (Docs)
- [ ] 그 외 (ETC)

## 작업 내용
- 이용내역 반납, 환급 분기처리 
- 이용내역의 첫번째 내역 색 오류 수정
- 계좌 등록 페이지에서 테블릿, 모바일 바텀시트 추가
## Before
<img width="1360" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/120862683/e041c592-e550-4c63-94ea-15a4e5881abf">

## After
<img width="1371" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/120862683/06531388-69c0-4133-90fc-91528cf42634">

![image](https://github.com/UPbrella/UPbrella_front/assets/120862683/52fe63a5-d4c0-43b7-b5e6-713450c803e0)



## To Reviewers (참고 사항, 첨부 자료 등)
 여전히 이 브랜치에 이전 커밋들이 담겨있는데 왜이런지모르겠네요ㅜ 아무래도 분기했던 브랜치에서 pr을 안올려서 그런것같습니다.
 마지막 커밋만 확인해주시면 됩니다. 죄송합니다