### PR TITLE
fix: 랜딩페이지 url -> 업브렐라 이야기 라우트로 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ function App() {
           <div className="bg-cover">
             <Routes>
               {/* width full */}
+              <Route path={"/"} element={<UpbrellaStoryPage />} />
               <Route path={"/about"} element={<UpbrellaStoryPage />} />
               <Route path="/information" element={<InfoPage />} />
 

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -1,7 +1,6 @@
 import ForbiddenPage from "@/components/pages/forbidden/ForbiddenPage";
 import RentPage from "@/components/pages/rent";
 import ReturnPage from "@/components/pages/return";
-import TempPage from "@/components/pages/temp/TempPage";
 import { TRoute } from "@/types/commonTypes";
 
 /**
@@ -24,10 +23,5 @@ export const NOT_LAYOUT_ROUTES: TRoute[] = [
     name: "접근 금지 페이지",
     path: "/forbidden",
     component: ForbiddenPage,
-  },
-  {
-    name: "메인 페이지",
-    path: "/",
-    component: TempPage,
   },
 ];


### PR DESCRIPTION
### PR Type\
- [x] 버그수정 (Bugfix)
- [x] 빌드, 배포 관련 변경 (Build, Deploy)

## 작업 내용
- 랜딩 페이지 (`/`) 라우트가 업브렐라 이야기로 매핑되어있었는데, 변경된 것 같아서 다시 수정했습니다.

## Before

## After

## To Reviewers (참고 사항, 첨부 자료 등)
