### PR TITLE
fix: 대여소 위치 페이지 컴포넌트 에러 수정

### DIFF
--- a/src/components/pages/RentalLocation/RentalLocationPage.tsx
+++ b/src/components/pages/RentalLocation/RentalLocationPage.tsx
@@ -31,6 +31,7 @@ const RentalInfo = () => {
   const [markers, setMarkers] = useState<naver.maps.Marker[]>([]);
   const [userPosition, setUserPosition] = useState<{ lat: number; lng: number } | null>(null);
   const [isBottomOpen, setIsBottomOpen] = useState(false);
+  const [showInitialCard, setShowInitialCard] = useState(true);
 
   // server
   const { data: classificationsRes } = useGetClassifications();
@@ -120,17 +121,17 @@ const RentalInfo = () => {
   ]);
 
   useEffect(() => {
-    if (storeMarker.data && storeMarker.data.length > 0 && showInitialCard) {
-      const randomIndex = Math.floor(Math.random() * storeMarker.data.length);
-      const randomStore = storeMarker.data[randomIndex].id;
+    if (storeListRes && storeListRes.length > 0 && showInitialCard) {
+      const randomIndex = Math.floor(Math.random() * storeListRes.length);
+      const randomStore = storeListRes[randomIndex].id;
       setSelectedStoreId(randomStore);
       setShowInitialCard(false);
     }
-  }, [storeMarker.data, showInitialCard]);
+  }, [storeListRes, showInitialCard]);
 
   useEffect(() => {
-    if (userPosition && storeMarker.data && storeMarker.data.length > 0) {
-      const distances = storeMarker.data.map((store) =>
+    if (userPosition && storeListRes && storeListRes.length > 0) {
+      const distances = storeListRes.map((store) =>
         getDistanceFromLatLonInKm(
           userPosition.lat,
           userPosition.lng,
@@ -142,10 +143,10 @@ const RentalInfo = () => {
       const minDistanceIndex = distances.indexOf(Math.min(...distances));
 
       if (!showInitialCard) {
-        setSelectedStoreId(storeMarker.data[minDistanceIndex].id);
+        setSelectedStoreId(storeListRes[minDistanceIndex].id);
       }
     }
-  }, [userPosition, storeMarker.data, showInitialCard]);
+  }, [userPosition, storeListRes, showInitialCard]);
 
   useEffect(() => {
     getUserPosition().then(
@@ -180,7 +181,6 @@ const RentalInfo = () => {
       setSelectedStoreId(selectedStore.id);
     }
   }, [storeListRes, userPosition]);
-
 
   return (
     <div className="flex flex-col mt-24">


### PR DESCRIPTION
### PR Type
- [x] 버그수정 (Bugfix)

## 작업 내용
- develop 브랜치에서 해당 페이지 런타임에러가 있길래 수정해서 올립니다.

## Before
<img width="2056" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76439533/b6c9e0d5-bed6-4e17-b494-a7f795b0e308">

## After
<img width="2026" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76439533/de166440-abc1-48eb-b5b6-d1b8348e08e8">


## To Reviewers (참고 사항, 첨부 자료 등)
- PR이 머지 되었을 때, 로컬에서 pull 받고 정상적으로 동작하는지 테스트를 한번 해보셨으면 하는 바람이 있습니다 ! 특히 충돌해결 후 머지나, 시간이 오래된 PR은 버전이 달라서 에러가 발생할 가능성이 높은 것 같아서요 !

- 그리고 혹시 채연님, 지점 바텀시트에 대해서는 다른 팀 분들과 협의하신 부분이 있으실까요 ? 예전에 바텀시트를 드래그 올렸을 때, 대여소 소개 컴포넌트로 전환이 된다거나 그런 이슈가 있었던 걸로 기억해서요 ~ 
@chaeyeon-yang 
