### PR TITLE
feat: 바텀시트 지점 상세카드에 버튼 추가

### DIFF
--- a/src/components/atoms/DetailBtn/index.stories.tsx
+++ b/src/components/atoms/DetailBtn/index.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryFn } from "@storybook/react";
+import DetailBtn, { TDetailBtn } from ".";
+import { BrowserRouter as Router } from "react-router-dom";
+
+export default {
+  title: "atoms/DetailBtn",
+  component: DetailBtn,
+  tags: ["autodocs"],
+} as Meta;
+
+// Story 함수의 타입 정의
+const Template: StoryFn<TDetailBtn> = (args) => (
+  <Router>
+    <DetailBtn {...args} />
+  </Router>
+);
+
+export const Default = Template.bind({});

--- a/src/components/atoms/DetailBtn/index.tsx
+++ b/src/components/atoms/DetailBtn/index.tsx
@@ -1,0 +1,24 @@
+import StorefrontOutlinedIcon from "@mui/icons-material/StorefrontOutlined";
+import { useNavigate } from "react-router-dom";
+
+export type TDetailBtn = {
+  id: number;
+};
+
+const DetailBtn = ({ id }: TDetailBtn) => {
+  const navigate = useNavigate();
+  const handleDetailClick = () => {
+    navigate(`/rentalOffice/${id}`);
+  };
+  return (
+    <button
+      className="text-center text-primary-500 rounded-99 w-full py-9 text-15 font-semibold border border-primary-500"
+      onClick={handleDetailClick}
+    >
+      <StorefrontOutlinedIcon className="mr-2" />
+      소개 더보기
+    </button>
+  );
+};
+
+export default DetailBtn;

--- a/src/components/atoms/NaverDirectionBtn/index.stories.tsx
+++ b/src/components/atoms/NaverDirectionBtn/index.stories.tsx
@@ -1,9 +1,8 @@
-import React from "react";
 import NaverDirectionBtn, { TNaverDirectionBtn } from "@/components/atoms/NaverDirectionBtn/index";
 import { Meta, StoryFn } from "@storybook/react";
 
 export default {
-  title: "Example/NaverDirectionBtn",
+  title: "atoms/NaverDirectionBtn",
   component: NaverDirectionBtn,
   tags: ["autodocs"],
 } as Meta;

--- a/src/components/molecules/MobileCard/index.tsx
+++ b/src/components/molecules/MobileCard/index.tsx
@@ -1,29 +1,31 @@
 import MobileCardInfo from "@/components/atoms/MobileCardInfo";
 import NaverDirectionBtn from "@/components/atoms/NaverDirectionBtn";
 import { TStoreListDetail } from "@/types/admin/StoreTypes";
+import DetailBtn from "@/components/atoms/DetailBtn";
 
 export type TMobileCard = {
   storeDetail: TStoreListDetail;
 };
 
-const MobileCard = (storeDetail: TMobileCard) => {
+const MobileCard = ({ storeDetail }: TMobileCard) => {
   return (
     <div className="mb-20 px-20 bg-white">
       <div className="flex justify-center items-center mb-16">
-        <div className="text-gray-700 text-16 font-semibold mr-8">
-          {storeDetail.storeDetail.name}
-        </div>
-        <div className="text-gray-600 text-12">{storeDetail.storeDetail.category}</div>
+        <div className="text-gray-700 text-16 font-semibold mr-8">{storeDetail.name}</div>
+        <div className="text-gray-600 text-12">{storeDetail.category}</div>
       </div>
       <div className="flex gap-x-2 mb-16">
-        <img className="rounded-8 w-120 h-120" src={storeDetail.storeDetail.imageUrls[0]}></img>
-        <MobileCardInfo storeDetail={storeDetail.storeDetail} />
+        <img className="rounded-8 w-120 h-120" src={storeDetail.imageUrls[0]}></img>
+        <MobileCardInfo storeDetail={storeDetail} />
       </div>
-      <NaverDirectionBtn
-        elon={storeDetail.storeDetail.longitude}
-        elat={storeDetail.storeDetail.latitude}
-        address={storeDetail.storeDetail.address}
-      />
+      <div className="grid grid-cols-2 gap-4">
+        <DetailBtn id={storeDetail.id} />
+        <NaverDirectionBtn
+          elon={storeDetail.longitude}
+          elat={storeDetail.latitude}
+          address={storeDetail.address}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/pages/RentalLocation/RentalLocationPage.tsx
+++ b/src/components/pages/RentalLocation/RentalLocationPage.tsx
@@ -212,7 +212,7 @@ const RentalInfo = () => {
                 isBottomSheetOpen={isBottomOpen}
                 setIsBottomSheetOpen={setIsBottomOpen}
                 snapPoints={[280, 280, 0]}
-                _className="hidden md:block sm:block"
+                _className="hidden lg:block"
               >
                 <MobileCard storeDetail={storeDetail} />
               </BottomSheet>


### PR DESCRIPTION
### PR Type

- [x] 기능 개발 (Feature)
- [x] 화면 작업 (Style, CSS)

## 작업 내용

- 기존 바텀시트에 '소개 더보기' 버튼이 추가되어 구현했습니다.

## Before

<img width="617" alt="스크린샷 2023-10-05 오후 11 16 46" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/bb65826c-1b1b-4124-8304-827512d21dd9">

## After

<img width="552" alt="스크린샷 2023-10-05 오후 11 10 02" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/cdd38465-0d38-4b2d-a5fa-00a397080322">

- 소개 더보기 버튼 클릭시 페이지 이동

<img width="538" alt="스크린샷 2023-10-05 오후 11 10 06" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/55534f1f-c97d-45cd-b55b-68b7735babbc">

## To Reviewers (참고 사항, 첨부 자료 등)

- 아직 확정되진 않았다고 하셨는데 미리 구현했습니다! 그래서 추후 수정사항 있을 수 있습니다.