### PR TITLE
design: lg사이즈에서 폰트크기, 마진 크기 수정

### DIFF
--- a/src/components/molecules/Mypage/MypageModal/index.tsx
+++ b/src/components/molecules/Mypage/MypageModal/index.tsx
@@ -9,7 +9,7 @@ const MypageModal = ({ children, width }: MypageModalProps) => {
       <div
         className={`w-${width} bg-white rounded-20 mx-20 xl:p-32 lg:p-20 flex justify-center items-center`}
       >
-        <div>{children}</div>
+        {children}
       </div>
     </div>
   );

--- a/src/components/molecules/Mypage/MypageModalChildren/index.tsx
+++ b/src/components/molecules/Mypage/MypageModalChildren/index.tsx
@@ -4,13 +4,15 @@ export type MypageModalChildrenProps = {
 };
 const MypageModalChildren = ({ label, onClickBtn }: MypageModalChildrenProps) => {
   return (
-    <div className="flex flex-col justify-center items-center">
-      <div className="text-gray-700 text-24 font-semibold leading-32 mb-24">{label}</div>
+    <div className="flex flex-1 flex-col justify-center items-center">
+      <div className="text-gray-700 text-24 font-semibold leading-32 mb-24 lg:mb-16 lg:text-18">
+        {label}
+      </div>
       <button
         className="w-160 h-56 px-32 flex justify-center items-center bg-primary-500 rounded-8"
         onClick={onClickBtn}
       >
-        <p className="text-white text-18 font-semibold leading-24">확인</p>
+        <p className="text-white text-18 font-semibold leading-24 lg:text-16">확인</p>
       </button>
     </div>
   );

--- a/src/components/molecules/Mypage/MypageModalTwoBtnChildren/index.tsx
+++ b/src/components/molecules/Mypage/MypageModalTwoBtnChildren/index.tsx
@@ -13,8 +13,8 @@ const MypageModalTwoBtnChildren = ({
   onClickOkay,
 }: MypageModalTwoBtnChildrenProps) => {
   return (
-    <div className="flex flex-col justify-center">
-      <div className="text-gray-700 text-24 font-semibold leading-32 xl:mb-24 lg:mb-16">
+    <div className="flex flex-1 flex-col justify-center">
+      <div className="flex justify-center text-gray-700 text-24 font-semibold leading-32 xl:mb-24 lg:mb-16 lg:text-18">
         {label}
       </div>
       {content ? (
@@ -40,13 +40,13 @@ const MypageModalTwoBtnChildren = ({
           className="w-full h-56 px-32 flex justify-center items-center bg-white rounded-8 border border-gray-300 mr-8"
           onClick={onClickCancel}
         >
-          <p className="text-gray-700 text-18 font-semibold leading-24">취소</p>
+          <p className="text-gray-700 text-18 font-semibold leading-24 lg:text-16">취소</p>
         </button>
         <button
           className="w-full h-56 px-32 flex justify-center items-center bg-primary-500 rounded-8"
           onClick={onClickOkay}
         >
-          <p className="text-white text-18 font-semibold leading-24">{btnLabel}</p>
+          <p className="text-white text-18 font-semibold leading-24 lg:text-16">{btnLabel}</p>
         </button>
       </div>
     </div>


### PR DESCRIPTION
### PR Type

- [X] 화면 작업 (Style, CSS)

## 작업 내용
화면크기가 lg이하일때 폰트크기와 마진이 디자인과 차이가 있어 수정했습니다.
## Before
<img width="497" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/120862683/a6373302-b60c-4e04-8e10-f6fc5217f9c2">
<img width="437" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/120862683/2435349e-732b-4365-a2ca-f31a84c2db17">

## After
<img width="388" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/120862683/aa38e5aa-5076-4635-b802-59459eeba4aa">


## To Reviewers (참고 사항, 첨부 자료 등)
