### PR TITLE
fix: 첫 렌더링 시 default StoreId 지정

### DIFF
--- a/src/components/molecules/Store/index.tsx
+++ b/src/components/molecules/Store/index.tsx
@@ -37,7 +37,7 @@ const Store = ({
   }, [selectedClassificationName, classifications]);
 
   return (
-    <div className="flex flex-col w-full h-full lg:max-w-600 smMaxLg:items-center">
+    <div className="flex flex-col w-full h-full lg:max-w-600 lg:mt-32 smMaxLg:items-center ">
       {storeList.map((store, index) => (
         <div key={index} className="w-full">
           <div

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -17,7 +17,8 @@ const RentalOfficePage = () => {
   // server
   const { data: subClassificationsRes } = useGetSubClassifications();
   const { data: storeListRes } = useGetStoreList();
-  const { data: useGetStoreDetailData } = useGetStoreDetail(selectedStoreId ?? 1);
+  const defalutStore = (storeListRes && storeListRes[0]?.stores[0]?.id) || 0;
+  const { data: useGetStoreDetailData } = useGetStoreDetail(selectedStoreId ?? defalutStore);
 
   return (
     <div className="block xl:flex gap-[24px]">


### PR DESCRIPTION
### PR Type

- [x] 버그수정 (Bugfix)

## 작업 내용

- 첫 렌더링 시에 selected된 스토어가 없을 경우 default storeId를 1로 하드코딩 해놓아서 왼쪽 스토어 카드가 안뜨는 문제점이 발생했습니다.
- 그래서 defaultStoreId를 지정했습니다.

## Before

<img width="1280" alt="스크린샷 2023-11-05 오후 10 31 45" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/6160c8e1-19bb-43a0-9e16-5a20f99d5ca1">

## After
<img width="1281" alt="스크린샷 2023-11-05 오후 10 32 00" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/34a2f098-3ed0-4399-aa50-f84b5a9498a9">


## To Reviewers (참고 사항, 첨부 자료 등)
