### PR TITLE
fix: 화면 구역 별 스크롤 및 랜덤 스토어 지정

### DIFF
--- a/src/components/molecules/Store/index.tsx
+++ b/src/components/molecules/Store/index.tsx
@@ -37,7 +37,7 @@ const Store = ({
   }, [selectedClassificationName, classifications]);
 
   return (
-    <div className="flex flex-col w-full h-full lg:max-w-600 smMaxLg:items-center">
+    <div className="flex flex-col w-full h-full lg:max-w-600 lg:mt-32 smMaxLg:items-center ">
       {storeList.map((store, index) => (
         <div key={index} className="w-full">
           <div

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -17,7 +17,8 @@ const RentalOfficePage = () => {
   // server
   const { data: subClassificationsRes } = useGetSubClassifications();
   const { data: storeListRes } = useGetStoreList();
-  const { data: useGetStoreDetailData } = useGetStoreDetail(selectedStoreId ?? 1);
+  const defalutStore = (storeListRes && storeListRes[0]?.stores[0]?.id) || 0;
+  const { data: useGetStoreDetailData } = useGetStoreDetail(selectedStoreId ?? defalutStore);
 
   return (
     <div className="block xl:flex gap-[24px]">

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -22,10 +22,12 @@ const RentalOfficePage = () => {
 
   return (
     <div className="block xl:flex gap-[24px]">
-      <div className="hidden xl:block max-w-[400px] min-w-[400px]">
-        {useGetStoreDetailData && <Card storeDetail={useGetStoreDetailData} />}
+      <div className="hidden xl:block max-w-[400px]">
+        <div className="overflow-auto max-h-screen pb-95">
+          {useGetStoreDetailData && <Card storeDetail={useGetStoreDetailData} />}
+        </div>
       </div>
-      <div className="flex flex-col items-center flex-1 xl:block">
+      <div className="flex flex-col items-center flex-1 xl:block overflow-auto">
         {subClassificationsRes && (
           <LocationClassificationBtn
             classifications={subClassificationsRes}

--- a/src/components/pages/rentalOffice/RentalOfficePage.tsx
+++ b/src/components/pages/rentalOffice/RentalOfficePage.tsx
@@ -6,7 +6,7 @@ import {
   useGetStoreList,
   useGetSubClassifications,
 } from "@/hooks/queries/storeQueries";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const RentalOfficePage = () => {
   // client
@@ -19,6 +19,15 @@ const RentalOfficePage = () => {
   const { data: storeListRes } = useGetStoreList();
   const defalutStore = (storeListRes && storeListRes[0]?.stores[0]?.id) || 0;
   const { data: useGetStoreDetailData } = useGetStoreDetail(selectedStoreId ?? defalutStore);
+
+  // default card 스토어
+  useEffect(() => {
+    if (storeListRes && storeListRes.length > 0) {
+      const randomIndex = Math.floor(Math.random() * storeListRes.length);
+      const randomStore = storeListRes[randomIndex].stores;
+      setSelectedStoreId(randomStore[0].id);
+    }
+  }, [storeListRes]);
 
   return (
     <div className="block xl:flex gap-[24px]">


### PR DESCRIPTION
### PR Type

- [x] 기능 개발 (Feature)

## 작업 내용

- 스토어 카드 따로 스크롤
- 스토어 목록 따로 스크롤
- ‼️ 왼쪽 카드의 default StoreId에 임의성 부여

## Before

- 전체 화면 통으로 스크롤

## After

- 카드 스크롤
<img width="1091" alt="스크린샷 2023-11-05 오후 11 44 21" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/0c044fb0-f423-48cf-99eb-4de278b7a3c4">


- 스토어 목록 스크롤
<img width="986" alt="스크린샷 2023-11-05 오후 11 44 08" src="https://github.com/UPbrella/UPbrella_front/assets/69382168/8f008526-99e3-451f-8c64-12a23f96f356">



## To Reviewers (참고 사항, 첨부 자료 등)
