### PR TITLE
fix: 대여 오류 문구 수정

### DIFF
--- a/src/components/pages/rent/index.tsx
+++ b/src/components/pages/rent/index.tsx
@@ -93,7 +93,7 @@ const RentPage = () => {
       <div>
         <ErrorComponent
           error="죄송합니다. 페이지를 찾을 수 없어요:("
-          subError="존재하지 않는 우산 고유 번호입니다."
+          subError="[ERROR] 해당 우산은 대여 불가능한 우산입니다."
         />
       </div>
     );


### PR DESCRIPTION
### PR Type
- [x] 그 외 (ETC)

## 작업 내용
다른 사용자가 빌린 우산을 빌리려고 할 때 등 범용적 문구로 변경 했습니다.

## Before
<img width="821" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76439533/cacf5dc8-3211-435e-b451-27c706e26725">

## After
<img width="828" alt="image" src="https://github.com/UPbrella/UPbrella_front/assets/76439533/a8af8d82-1d51-4b0d-8d64-30f03f5f7d8d">


## To Reviewers (참고 사항, 첨부 자료 등)
