### PR TITLE
fix: 대여, 반납 폼 빈 화면 버그 수정

### DIFF
--- a/src/utils/PrivateRoutes.tsx
+++ b/src/utils/PrivateRoutes.tsx
@@ -1,22 +1,19 @@
-import { loginState, redirectUrl } from "@/recoil";
-import React, { useLayoutEffect } from "react";
+import { useGetUserStatus } from "@/hooks/queries/userQueries";
+import { redirectUrl } from "@/recoil";
+import React from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 
 const PrivateRoutes: React.FC = () => {
-  const authState = useRecoilValue(loginState);
   const { pathname, search } = useLocation();
-  const path = pathname + search;
+  const { isLoading, isError } = useGetUserStatus();
 
+  const path = pathname + search;
   const setRedirectUrl = useSetRecoilState(redirectUrl);
 
-  useLayoutEffect(() => {
-    if (!authState) {
-      setRedirectUrl(path);
-    }
-  }, [authState, path, setRedirectUrl]);
-
-  if (!authState) {
+  if (isLoading) return <></>;
+  if (isError) {
+    setRedirectUrl(path);
     return <Navigate to="/login" replace={true} />;
   }
 


### PR DESCRIPTION
### PR Type
- [x] 버그수정 (Bugfix)

## 작업 내용
로그인 세션 만료 시, 대여, 반납 페이지에 빈 화면이 뜨는 버그를 수정했습니다.

- `PrivateRoutes` 컴포넌트에서 recoil `loginState` 값과 server 데이터 값이 동기화되지 않아서 생긴 문제라 추측하여, recoil 을 덜어내고 useQuery로 직접 요청하도록 수정했습니다.

## Before

## After

## To Reviewers (참고 사항, 첨부 자료 등)
