### PR TITLE
fix: toast 메세지 수정

### DIFF
--- a/src/components/pages/admin/rent/RentHistoryPage.tsx
+++ b/src/components/pages/admin/rent/RentHistoryPage.tsx
@@ -134,11 +134,9 @@ const RentHistoryPage = () => {
             const minWidth = RENT_ADMIN_TABLE[field].width ?? "130px";
             const header = RENT_ADMIN_TABLE[field].label;
             const dropDownOptions = RENT_ADMIN_TABLE[field].options;
-            const sortable = !RENT_ADMIN_TABLE[field].notSort;
 
             return (
               <Column
-                sortable={sortable}
                 key={key}
                 style={{ minWidth }}
                 field={field}
@@ -248,13 +246,12 @@ export const RENT_ADMIN_TABLE: Record<
     label: string;
     width?: number;
     options?: { label: string; value: boolean }[];
-    notSort?: boolean;
   }
 > = {
   id: { label: "일련 번호", width: 100 },
   name: { label: "이름" },
   phoneNumber: { label: "전화번호", width: 150 },
-  rentStoreName: { label: "대여 지점", notSort: true },
+  rentStoreName: { label: "대여 지점" },
   rentAt: { label: "대여 날짜", width: 150 },
   umbrellaUuid: { label: "우산 고유 번호" },
   elapsedDay: { label: "대여 경과 일수" },
@@ -268,17 +265,16 @@ export const RENT_ADMIN_TABLE: Record<
   },
   refundCompleted: {
     label: "보증금 환급 여부",
-    notSort: true,
     width: 150,
     options: [
       { label: "환급 완료", value: true },
       { label: "미완료", value: false },
     ],
   },
-  bank: { label: "환급 은행", notSort: true },
-  accountNumber: { label: "환급 계좌 번호", width: 150, notSort: true },
+  bank: { label: "환급 은행" },
+  accountNumber: { label: "환급 계좌 번호", width: 150 },
   returnAt: { label: "반납 날짜", width: 150 },
-  returnStoreName: { label: "반납 지점", notSort: true },
+  returnStoreName: { label: "반납 지점" },
   totalRentalDay: { label: "총 대여 기간" },
-  etc: { label: "비고", notSort: true },
+  etc: { label: "비고" },
 };

--- a/src/components/pages/rent/index.tsx
+++ b/src/components/pages/rent/index.tsx
@@ -118,7 +118,7 @@ const RentPage = () => {
             setIsOpenLockPwModal(true);
           } else {
             setIsRent(true);
-            toast.success("대여 완료되었습니다.");
+            toast.success("우산 대여 완료!");
           }
         },
       }

--- a/src/components/pages/return/index.tsx
+++ b/src/components/pages/return/index.tsx
@@ -182,7 +182,7 @@ const ReturnPage = () => {
         },
         onSuccess: () => {
           setIsReturn(true);
-          toast.success("반납 완료되었습니다.");
+          toast.success("우산 반납 완료!");
           return;
         },
       }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,18 +1,26 @@
-import ReactDOM from "react-dom/client";
-import App from "./App.tsx";
 import "./index.css";
 import "@/styles/fonts/font.css";
+import "primereact/resources/themes/lara-light-indigo/theme.css"; //theme
+import "primereact/resources/primereact.min.css"; //core css
+import "primeicons/primeicons.css";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import { Suspense } from "react";
 import { BrowserRouter } from "react-router-dom";
 import { ThemeProvider, createTheme } from "@mui/material";
 import { Global, css } from "@emotion/react";
 import { RecoilRoot } from "recoil";
-import { Suspense } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Toaster } from "react-hot-toast";
+import { ToastPosition, Toaster } from "react-hot-toast";
 import { HelmetProvider } from "react-helmet-async";
-import "primereact/resources/themes/lara-light-indigo/theme.css"; //theme
-import "primereact/resources/primereact.min.css"; //core css
-import "primeicons/primeicons.css";
+import { isMobile } from "react-device-detect";
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    kakao: any;
+  }
+}
 
 const globalStyles = css`
   * {
@@ -37,13 +45,6 @@ const theme = createTheme({
   },
 });
 
-declare global {
-  interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    kakao: any;
-  }
-}
-
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -55,6 +56,27 @@ const queryClient = new QueryClient({
   },
 });
 
+const toastProps = {
+  position: (isMobile ? "bottom-center" : "top-center") as ToastPosition,
+  options: {
+    icon: null,
+    style: {
+      padding: "12px 16px",
+      color: "#fff",
+      background: "#111111",
+      fontSize: "15px",
+      fontWeight: "400",
+      width: "320px",
+    },
+    duration: 3000,
+    error: {
+      style: {
+        background: "#E05938",
+      },
+    },
+  },
+};
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <BrowserRouter>
     <RecoilRoot>
@@ -62,18 +84,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
         <QueryClientProvider client={queryClient}>
           <ThemeProvider theme={theme}>
             <HelmetProvider>
-              <Toaster
-                position="top-center"
-                toastOptions={{
-                  style: { padding: "16px", color: "#fff", background: "#5DCF17" },
-                  duration: 3000,
-                  error: {
-                    style: {
-                      background: "#FF513E",
-                    },
-                  },
-                }}
-              />
+              <Toaster position={toastProps.position} toastOptions={toastProps.options} />
               <Global styles={globalStyles} />
               <App />
             </HelmetProvider>


### PR DESCRIPTION
### PR Type
- [x] 화면 작업 (Style, CSS)
- [x] 리팩토링 (no functional changes, no api changes)

## 작업 내용
- toast 메세지 스타일 수정
- 문구 수정 (대여, 반납 토스트 메세지)
- 어드민 > 대여 히스토리 테이블 필터 기능 삭제

## Before
- 항상 top
![image](https://github.com/UPbrella/UPbrella_front/assets/76439533/9eb3cb4b-e25b-4ab7-9fb9-7415d3372ba2)


## After
- pc는 top, mobile은 bottom
![image](https://github.com/UPbrella/UPbrella_front/assets/76439533/21bc82ed-cd74-4edb-baf2-11e811dbdc18)


## To Reviewers (참고 사항, 첨부 자료 등)
