### PR TITLE
fix: contact us 헤더 마진 수정

### DIFF
--- a/src/components/pages/contact/ContactPage.tsx
+++ b/src/components/pages/contact/ContactPage.tsx
@@ -1,5 +1,5 @@
 import Instagram from "@/components/atoms/Contact/Instagram";
-import React, { useEffect, useRef, useState } from "react";
+import React, { ReactNode, useEffect, useRef, useState } from "react";
 import Input from "@/components/atoms/Contact/Input";
 import TextArea from "@/components/atoms/Contact/TextArea";
 import Button from "@/components/atoms/Contact/Button";
@@ -8,7 +8,6 @@ import { formatPhoneNumber } from "@/utils/utils";
 import toast from "react-hot-toast";
 import Footer from "@/components/organisms/Footer";
 import { HeaderContainer } from "@/components/organisms/Header/HeaderContainer";
-import { FixWidthWrapper } from "@/components/pages/story/UpbrellaStoryPage";
 import SeoMetaTag from "@/utils/SeoMetaTag";
 
 const ContactPage = () => {
@@ -160,6 +159,10 @@ const ContactPage = () => {
       </div>
     </>
   );
+};
+
+export const FixWidthWrapper = ({ children }: { children: ReactNode }) => {
+  return <div className="max-w-[1440px] mx-auto md:px-20 sm:mx-0">{children}</div>;
 };
 
 export default ContactPage;


### PR DESCRIPTION
### PR Type

- [ ] 기능 개발 (Feature)
- [ ] 코드 스타일 변경 (Code style update) (formatting, local variables)
- [x] 화면 작업 (Style, CSS)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 버그수정 (Bugfix)
- [ ] 빌드, 배포 관련 변경 (Build, Deploy)
- [ ] 문서 작업 (Docs)
- [ ] 그 외 (ETC)

## 작업 내용
contact us 페이지의 헤더 좌우 마진이 다른 페이지와 통일되지 않음 

## Before
contact us 페이지 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b82b8121-68c7-495c-a5f2-b589bdc882d5" />


다른 페이지 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/629cd0ec-48cc-4edc-8d55-661141955237" />

## After

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a68d0ce1-cefd-4645-9fa4-babe958ffcc7" />


## To Reviewers (참고 사항, 첨부 자료 등)
