### PR TITLE
fix: footer 너비 100% 설정

### DIFF
--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -4,7 +4,7 @@ import { FixWidthWrapper } from "@/components/pages/story/UpbrellaStoryPage";
 
 const Footer = () => {
   return (
-    <div className="hidden py-20 border-t border-gray-100 xl:block">
+    <div className="w-full hidden py-20 border-t border-gray-100 xl:block">
       <FixWidthWrapper>
         <div className="flex justify-between">
           <FooterLabel />


### PR DESCRIPTION
### PR Type

- [x] 화면 작업 (Style, CSS)
- [x] 버그수정 (Bugfix)

## 작업 내용
- 마이페이지 푸터 너비가 100% 설정돼있지 않아 중간으로 몰려있음 

## Before
<img width="1512" alt="스크린샷 2025-06-30 19 00 26" src="https://github.com/user-attachments/assets/6590cf0e-1a44-4013-95b1-66779b7f6385" />

## After
<img width="1512" alt="스크린샷 2025-06-30 18 59 59" src="https://github.com/user-attachments/assets/f304bc87-b2ff-4eb9-a09f-e0ffade038a0" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Footer component to ensure it spans the full width of the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->