### PR TITLE
feat: 계좌 수정

### DIFF
--- a/src/constants/Account.ts
+++ b/src/constants/Account.ts
@@ -1,3 +1,3 @@
 export const BANK_NAME = "카카오뱅크";
-export const ACCOUNT_NUMBER = "7942-04-37762";
-export const ACCOUNT_NAME = "최한별";
+export const ACCOUNT_NUMBER = "79422185860";
+export const ACCOUNT_NAME = "황주연";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated displayed account details for transfers: account holder is now 황주연 and account number is 79422185860.
  - Bank name remains unchanged.
  - Changes apply wherever account information is shown (e.g., payment or transfer instructions) to ensure users see current details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->