### PR TITLE
[feat] 헤더·모바일에서 한/영 언어 전환 지원

### DIFF
--- a/src/shared/lib/i18n/index.ts
+++ b/src/shared/lib/i18n/index.ts
@@ -4,7 +4,10 @@ import { initReactI18next } from "react-i18next";
 import en from "./locales/en.json";
 import ko from "./locales/ko.json";
 
-const locale = import.meta.env.VITE_LOCALE || "ko";
+const detectBrowserLang = (): "ko" | "en" => (navigator.language.startsWith("en") ? "en" : "ko");
+
+const locale =
+  localStorage.getItem("upbrella-lang") || import.meta.env.VITE_LOCALE || detectBrowserLang();
 
 i18n.use(initReactI18next).init({
   resources: {

--- a/src/shared/ui/LanguageSwitcher/index.tsx
+++ b/src/shared/ui/LanguageSwitcher/index.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from "react-i18next";
+
+const LanguageSwitcher = () => {
+  const { i18n } = useTranslation();
+  const isKo = i18n.language === "ko";
+
+  const switchLang = (lang: "ko" | "en") => {
+    i18n.changeLanguage(lang);
+    localStorage.setItem("upbrella-lang", lang);
+  };
+
+  return (
+    <div className="flex gap-2 items-center font-semibold text-14">
+      <ToggleButton onClick={() => switchLang("ko")} isActive={isKo}>
+        KOR
+      </ToggleButton>
+      <div className="w-px h-12 min-w-[1px] bg-gray-300" />
+      <ToggleButton onClick={() => switchLang("en")} isActive={!isKo}>
+        ENG
+      </ToggleButton>
+    </div>
+  );
+};
+
+const ToggleButton = ({
+  onClick,
+  children,
+  isActive,
+}: {
+  onClick: () => void;
+  children: React.ReactNode;
+  isActive: boolean;
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`grid place-items-center leading-none ${
+        isActive ? "font-bold" : "font-medium text-gray-600"
+      }`}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/widgets/header/ui/HeaderContainer.tsx
+++ b/src/widgets/header/ui/HeaderContainer.tsx
@@ -8,6 +8,7 @@ import { useGetUserStatus } from "@/entities/user/api/user.queries";
 import { TUserRes } from "@/entities/user/model/types";
 import Logo from "@/shared/assets/main_logo.svg";
 import { FixWidthWrapper } from "@/shared/ui/FixWidthWrapper";
+import LanguageSwitcher from "@/shared/ui/LanguageSwitcher";
 import HeaderMyPage from "@/widgets/header/ui/HeaderMyPage";
 import MobileMenu from "@/widgets/header/ui/MobileMenu";
 import ArrowBackIosNewSharpIcon from "@mui/icons-material/ArrowBackIosNewSharp";
@@ -102,7 +103,7 @@ const DesktopHeader = ({ isLoading, userRes }: THeaderProps) => {
               key={nameKey}
               to={path}
               className={({ isActive }) => {
-                let defaultClassName = "transition-all mr-32 p-8 flex items-center";
+                let defaultClassName = "transition-all mr-12 2xl:mr-32 p-8 flex items-center";
                 if (isActive) {
                   defaultClassName +=
                     " text-primary-500 border-solid border-b-2 border-primary-500";
@@ -115,6 +116,10 @@ const DesktopHeader = ({ isLoading, userRes }: THeaderProps) => {
             </NavLink>
           );
         })}
+
+        <div className="flex items-center p-8 mr-12 2xl:mr-32">
+          <LanguageSwitcher />
+        </div>
 
         {userRes ? (
           <div

--- a/src/widgets/header/ui/MobileMenu.tsx
+++ b/src/widgets/header/ui/MobileMenu.tsx
@@ -1,17 +1,16 @@
-import { Link, useNavigate } from "react-router-dom";
-import { NavLink } from "react-router-dom";
-import Logo from "@/shared/assets/main_logo.svg";
-import CloseSharpIcon from "@mui/icons-material/CloseSharp";
-import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
-import NavigateNextIcon from "@mui/icons-material/NavigateNext";
+import { BACKGROUND_IMAGE_ROUTES_URL, LAYOUT_ROUTES_URL } from "@/app/router/routes";
+import CardFooter from "@/entities/store/ui/CardFooter";
 import { useLogout } from "@/entities/user/api/user.queries";
 import { TUserRes } from "@/entities/user/model/types";
+import Logo from "@/shared/assets/main_logo.svg";
+import LanguageSwitcher from "@/shared/ui/LanguageSwitcher";
+import { headerNavItems } from "@/widgets/header/ui/HeaderContainer";
+import CloseSharpIcon from "@mui/icons-material/CloseSharp";
+import NavigateNextIcon from "@mui/icons-material/NavigateNext";
+import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
 import { Fragment } from "react";
 import { useTranslation } from "react-i18next";
-import CardFooter from "@/entities/store/ui/CardFooter";
-import { headerNavItems } from "@/widgets/header/ui/HeaderContainer";
-import { LAYOUT_ROUTES_URL } from "@/app/router/routes";
-import { BACKGROUND_IMAGE_ROUTES_URL } from "@/app/router/routes";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 
 type TMenu = {
   userRes: TUserRes | null;
@@ -38,12 +37,12 @@ const MobileMenu: React.FC<TMenu> = ({ userRes, setMenuOpen }) => {
   };
 
   return (
-    <div className="relative flex flex-col justify-between w-full h-full">
+    <div className="flex relative flex-col justify-between w-full h-full">
       <div className="bg-white z-100">
-        <div className="flex items-center justify-between py-16">
+        <div className="flex justify-between items-center py-16">
           <Link to={"/"}>
             <img
-              className="w-32 h-32"
+              className="p-2 w-32 h-32"
               src={Logo}
               alt="Logo"
               onError={(e) => {
@@ -51,8 +50,13 @@ const MobileMenu: React.FC<TMenu> = ({ userRes, setMenuOpen }) => {
               }}
             />
           </Link>
-          <div className="cursor-pointer" onClick={handleMenuClose}>
-            <CloseSharpIcon />
+          <div className="flex gap-3 items-center">
+            <div className="pt-2">
+              <LanguageSwitcher />
+            </div>
+            <div className="cursor-pointer" onClick={handleMenuClose}>
+              <CloseSharpIcon />
+            </div>
           </div>
         </div>
 
@@ -64,7 +68,7 @@ const MobileMenu: React.FC<TMenu> = ({ userRes, setMenuOpen }) => {
                 <span className="ml-8">{userRes.name}</span>
               </div>
               <button
-                className="flex items-center justify-center py-8 pl-16 pr-6 font-semibold transition-all text-primary-500 bg-primary-200 rounded-99 text-14"
+                className="flex justify-center items-center py-8 pr-6 pl-16 font-semibold transition-all text-primary-500 bg-primary-200 rounded-99 text-14"
                 onClick={() => handleNavToUrl(LAYOUT_ROUTES_URL.myPageRent.path())}
               >
                 {t("common.mobile.mypage")} <NavigateNextIcon fontSize="small" />
@@ -76,7 +80,7 @@ const MobileMenu: React.FC<TMenu> = ({ userRes, setMenuOpen }) => {
                 {t("common.mobile.greeting")}
               </div>
               <button
-                className="w-full py-12 font-semibold text-white rounded-8 bg-primary-500"
+                className="py-12 w-full font-semibold text-white rounded-8 bg-primary-500"
                 onClick={() => handleNavToUrl(BACKGROUND_IMAGE_ROUTES_URL.login.path())}
               >
                 {t("common.mobile.login")}
@@ -91,7 +95,7 @@ const MobileMenu: React.FC<TMenu> = ({ userRes, setMenuOpen }) => {
 
             return (
               <Fragment key={nameKey}>
-                <div className="w-full h-1 my-16 bg-gray-200"></div>
+                <div className="my-16 w-full h-1 bg-gray-200"></div>
                 <div>
                   <NavLink
                     onClick={() => handleMenuClose()}
@@ -105,7 +109,7 @@ const MobileMenu: React.FC<TMenu> = ({ userRes, setMenuOpen }) => {
               </Fragment>
             );
           })}
-          <div className="w-full h-1 my-16 bg-gray-200"></div>
+          <div className="my-16 w-full h-1 bg-gray-200"></div>
           {userRes && (
             <button
               className="flex mx-16 font-semibold transition-all text-14 hover:text-primary-500"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,7 @@ export default {
       mdMaxLg: { max: "1279px", min: "1025px" },
       lgMaxMin: { max: "1279px", min: "640px" },
       xl: { min: "1025px" },
+      "2xl": { min: "1280px" },
     },
     fontSize: {
       h14: ["14px", "20px"],


### PR DESCRIPTION
<!--
PR 작성 전 한 번씩 읽어주세요.

# How to write Good Commit Message
# 1. Specify the type of commit: feat, enh, bugfix, style, docs
# 2. Separate the subject from the body with a blank line
# 3. Your commit message should not contain any whitespace errors
# 4. Remove unnecessary punctuation marks
# 5. Do not end the subject line with a period
# 6. Capitalize the subject line and each paragraph
# 7. Use the imperative mood in the subject line
# 8. Use the body to explain what changes you have made and why you made them.
# 9. Do not assume the reviewer understands what the original problem was, ensure you add it.
# 10. Do not think your code is self-explanatory
# 11. Follow the commit convention defined by your team
-->

## Issue?

관련 이슈 없음

## Changes?

- `LanguageSwitcher` 공유 UI로 KOR/ENG 전환 버튼 추가, 선택 언어를 `localStorage`(`upbrella-lang`)에 저장
- i18n 초기 로케일: 저장된 값 → `VITE_LOCALE` → 브라우저 `navigator.language` 순으로 결정
- 데스크톱 헤더 네비·언어 스위처 레이아웃 및 `mr-12`/`2xl:mr-32` 반응형 여백
- 모바일 메뉴 상단(닫기 옆)에 동일 스위처 배치, 일부 클래스 순서만 prettier 정리
- Tailwind에 `2xl`(min 1280px) 스크린 브레이크포인트 추가

## Why we need?

사용자가 앱에서 한국어/영어를 직접 바꿀 수 있고, 새로고침 후에도 선택 언어가 유지되어 글로벌/로컬 모두 사용성이 좋아집니다.

## Test?

- `pnpm dev`로 로컬 실행 후 헤더·모바일 메뉴에서 KOR/ENG 클릭 시 문구 전환 확인
- 새로고침 후에도 마지막 선택 언어 유지 확인

## CC (Optional)

<!-- 필요 시 멘션 -->

## Anything else? (Optional)

없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language switcher component now available in both desktop and mobile header interfaces, enabling users to toggle between Korean and English
  * Automatic browser language detection implemented with persistent user preference storage

* **Style**
  * New Tailwind responsive breakpoint added to support extended display configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->